### PR TITLE
Added the 'explicit' qualifier to class constructors

### DIFF
--- a/fuzzylite/fl/Console.h
+++ b/fuzzylite/fl/Console.h
@@ -40,7 +40,7 @@ namespace fl {
         struct Option {
             std::string key, value, description;
 
-            Option(const std::string& key = "", const std::string& value = "", const std::string& description = "") :
+            explicit Option(const std::string& key = "", const std::string& value = "", const std::string& description = "") :
             key(key), value(value), description(description) {
             }
         };

--- a/fuzzylite/fl/Engine.h
+++ b/fuzzylite/fl/Engine.h
@@ -55,7 +55,7 @@ namespace fl {
         void updateReferences() const;
 
     public:
-        Engine(const std::string& name = "");
+        explicit Engine(const std::string& name = "");
         Engine(const Engine& other);
         Engine& operator=(const Engine& other);
         virtual ~Engine();

--- a/fuzzylite/fl/Exception.h
+++ b/fuzzylite/fl/Exception.h
@@ -37,7 +37,7 @@ namespace fl {
     protected:
         std::string _what;
     public:
-        Exception(const std::string& what);
+        explicit Exception(const std::string& what);
         Exception(const std::string& what, const std::string& file, int line,
                 const std::string& function);
         virtual ~Exception() FL_INOEXCEPT FL_IOVERRIDE;

--- a/fuzzylite/fl/defuzzifier/Bisector.h
+++ b/fuzzylite/fl/defuzzifier/Bisector.h
@@ -31,7 +31,7 @@ namespace fl {
 
     class FL_API Bisector : public IntegralDefuzzifier {
     public:
-        Bisector(int resolution = defaultResolution());
+        explicit Bisector(int resolution = defaultResolution());
         virtual ~Bisector() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Bisector)
 

--- a/fuzzylite/fl/defuzzifier/Centroid.h
+++ b/fuzzylite/fl/defuzzifier/Centroid.h
@@ -31,7 +31,7 @@ namespace fl {
 
     class FL_API Centroid : public IntegralDefuzzifier {
     public:
-        Centroid(int resolution = defaultResolution());
+        explicit Centroid(int resolution = defaultResolution());
         virtual ~Centroid() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Centroid)
 

--- a/fuzzylite/fl/defuzzifier/IntegralDefuzzifier.h
+++ b/fuzzylite/fl/defuzzifier/IntegralDefuzzifier.h
@@ -40,7 +40,7 @@ namespace fl {
         static void setDefaultResolution(int defaultResolution);
         static int defaultResolution();
 
-        IntegralDefuzzifier(int resolution = defaultResolution());
+        explicit IntegralDefuzzifier(int resolution = defaultResolution());
         virtual ~IntegralDefuzzifier() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(IntegralDefuzzifier)
 

--- a/fuzzylite/fl/defuzzifier/LargestOfMaximum.h
+++ b/fuzzylite/fl/defuzzifier/LargestOfMaximum.h
@@ -31,7 +31,7 @@ namespace fl {
 
     class FL_API LargestOfMaximum : public IntegralDefuzzifier {
     public:
-        LargestOfMaximum(int resolution = defaultResolution());
+        explicit LargestOfMaximum(int resolution = defaultResolution());
         virtual ~LargestOfMaximum() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(LargestOfMaximum)
 

--- a/fuzzylite/fl/defuzzifier/MeanOfMaximum.h
+++ b/fuzzylite/fl/defuzzifier/MeanOfMaximum.h
@@ -31,7 +31,7 @@ namespace fl {
 
     class FL_API MeanOfMaximum : public IntegralDefuzzifier {
     public:
-        MeanOfMaximum(int resolution = defaultResolution());
+        explicit MeanOfMaximum(int resolution = defaultResolution());
         virtual ~MeanOfMaximum() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(MeanOfMaximum)
 

--- a/fuzzylite/fl/defuzzifier/SmallestOfMaximum.h
+++ b/fuzzylite/fl/defuzzifier/SmallestOfMaximum.h
@@ -31,7 +31,7 @@ namespace fl {
 
     class FL_API SmallestOfMaximum : public IntegralDefuzzifier {
     public:
-        SmallestOfMaximum(int resolution = defaultResolution());
+        explicit SmallestOfMaximum(int resolution = defaultResolution());
         virtual ~SmallestOfMaximum() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(SmallestOfMaximum)
 

--- a/fuzzylite/fl/defuzzifier/WeightedAverage.h
+++ b/fuzzylite/fl/defuzzifier/WeightedAverage.h
@@ -32,8 +32,8 @@ namespace fl {
 
     class FL_API WeightedAverage : public WeightedDefuzzifier {
     public:
-        WeightedAverage(Type type = Automatic);
-        WeightedAverage(const std::string& type);
+        explicit WeightedAverage(Type type = Automatic);
+        explicit WeightedAverage(const std::string& type);
         virtual ~WeightedAverage() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(WeightedAverage)
 

--- a/fuzzylite/fl/defuzzifier/WeightedDefuzzifier.h
+++ b/fuzzylite/fl/defuzzifier/WeightedDefuzzifier.h
@@ -38,8 +38,8 @@ namespace fl {
         };
         static std::string typeName(Type);
 
-        WeightedDefuzzifier(Type type = Automatic);
-        WeightedDefuzzifier(const std::string& type);
+        explicit WeightedDefuzzifier(Type type = Automatic);
+        explicit WeightedDefuzzifier(const std::string& type);
         virtual ~WeightedDefuzzifier() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(WeightedDefuzzifier)
 

--- a/fuzzylite/fl/defuzzifier/WeightedSum.h
+++ b/fuzzylite/fl/defuzzifier/WeightedSum.h
@@ -32,8 +32,8 @@ namespace fl {
 
     class FL_API WeightedSum : public WeightedDefuzzifier {
     public:
-        WeightedSum(Type type = Automatic);
-        WeightedSum(const std::string& type);
+        explicit WeightedSum(Type type = Automatic);
+        explicit WeightedSum(const std::string& type);
         virtual ~WeightedSum() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(WeightedSum)
 

--- a/fuzzylite/fl/factory/CloningFactory.h
+++ b/fuzzylite/fl/factory/CloningFactory.h
@@ -40,7 +40,7 @@ namespace fl {
         std::map<std::string, T> _objects;
 
     public:
-        CloningFactory(const std::string& name = "");
+        explicit CloningFactory(const std::string& name = "");
         CloningFactory(const CloningFactory& other);
         CloningFactory& operator=(const CloningFactory& other);
         virtual ~CloningFactory();

--- a/fuzzylite/fl/factory/ConstructionFactory.h
+++ b/fuzzylite/fl/factory/ConstructionFactory.h
@@ -43,7 +43,7 @@ namespace fl {
         std::map<std::string, Constructor> _constructors;
 
     public:
-        ConstructionFactory(const std::string& name);
+        explicit ConstructionFactory(const std::string& name);
         virtual ~ConstructionFactory();
         FL_DEFAULT_COPY_AND_MOVE(ConstructionFactory)
 

--- a/fuzzylite/fl/imex/CppExporter.h
+++ b/fuzzylite/fl/imex/CppExporter.h
@@ -42,7 +42,7 @@ namespace fl {
         bool _prefixNamespace;
         virtual std::string fl(const std::string& clazz) const;
     public:
-        CppExporter(bool prefixNamespace = false);
+        explicit CppExporter(bool prefixNamespace = false);
         virtual ~CppExporter() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(CppExporter)
 

--- a/fuzzylite/fl/imex/FclExporter.h
+++ b/fuzzylite/fl/imex/FclExporter.h
@@ -38,7 +38,7 @@ namespace fl {
         std::string _indent;
 
     public:
-        FclExporter(const std::string& indent = "  ");
+        explicit FclExporter(const std::string& indent = "  ");
         virtual ~FclExporter() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(FclExporter)
 

--- a/fuzzylite/fl/imex/FldExporter.h
+++ b/fuzzylite/fl/imex/FldExporter.h
@@ -41,7 +41,7 @@ namespace fl {
         bool _exportInputValues;
         bool _exportOutputValues;
     public:
-        FldExporter(const std::string& separator = " ");
+        explicit FldExporter(const std::string& separator = " ");
         virtual ~FldExporter() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(FldExporter)
 

--- a/fuzzylite/fl/imex/FllExporter.h
+++ b/fuzzylite/fl/imex/FllExporter.h
@@ -44,7 +44,7 @@ namespace fl {
         std::string _indent;
         std::string _separator;
     public:
-        FllExporter(const std::string& indent = "  ", const std::string& separator = "\n");
+        explicit FllExporter(const std::string& indent = "  ", const std::string& separator = "\n");
         virtual ~FllExporter() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(FllExporter)
 

--- a/fuzzylite/fl/imex/FllImporter.h
+++ b/fuzzylite/fl/imex/FllImporter.h
@@ -39,7 +39,7 @@ namespace fl {
     protected:
         std::string _separator;
     public:
-        FllImporter(const std::string& separator = "\n");
+        explicit FllImporter(const std::string& separator = "\n");
         virtual ~FllImporter() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(FllImporter)
 

--- a/fuzzylite/fl/rule/Rule.h
+++ b/fuzzylite/fl/rule/Rule.h
@@ -48,7 +48,7 @@ namespace fl {
         std::map<std::string, Hedge*> _hedges;
 
     public:
-        Rule(const std::string& text = "", scalar weight = 1.0);
+        explicit Rule(const std::string& text = "", scalar weight = 1.0);
         Rule(const Rule& other);
         Rule& operator=(const Rule& other);
         virtual ~Rule();

--- a/fuzzylite/fl/rule/RuleBlock.h
+++ b/fuzzylite/fl/rule/RuleBlock.h
@@ -50,7 +50,7 @@ namespace fl {
         bool _enabled;
 
     public:
-        RuleBlock(const std::string& name = "");
+        explicit RuleBlock(const std::string& name = "");
         RuleBlock(const RuleBlock& other);
         RuleBlock& operator=(const RuleBlock& other);
         virtual ~RuleBlock();

--- a/fuzzylite/fl/term/Accumulated.h
+++ b/fuzzylite/fl/term/Accumulated.h
@@ -43,7 +43,7 @@ namespace fl {
         scalar _minimum, _maximum;
         FL_unique_ptr<SNorm> _accumulation;
     public:
-        Accumulated(const std::string& name = "",
+        explicit Accumulated(const std::string& name = "",
                 scalar minimum = fl::nan,
                 scalar maximum = fl::nan,
                 SNorm* accumulation = fl::null);

--- a/fuzzylite/fl/term/Activated.h
+++ b/fuzzylite/fl/term/Activated.h
@@ -37,7 +37,7 @@ namespace fl {
         const TNorm* _activation;
 
     public:
-        Activated(const Term* term = fl::null, scalar degree = 1.0,
+        explicit Activated(const Term* term = fl::null, scalar degree = 1.0,
                 const TNorm* activationOperator = fl::null);
         virtual ~Activated() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Activated)

--- a/fuzzylite/fl/term/Bell.h
+++ b/fuzzylite/fl/term/Bell.h
@@ -35,7 +35,7 @@ namespace fl {
         scalar _width;
         scalar _slope;
     public:
-        Bell(const std::string& name = "",
+        explicit Bell(const std::string& name = "",
                 scalar center = fl::nan,
                 scalar width = fl::nan,
                 scalar slope = fl::nan,

--- a/fuzzylite/fl/term/Concave.h
+++ b/fuzzylite/fl/term/Concave.h
@@ -34,7 +34,7 @@ namespace fl {
     protected:
         scalar _inflection, _end;
     public:
-        Concave(const std::string& name = "",
+        explicit Concave(const std::string& name = "",
                 scalar inflection = fl::nan,
                 scalar end = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/Constant.h
+++ b/fuzzylite/fl/term/Constant.h
@@ -34,7 +34,7 @@ namespace fl {
         scalar _value;
 
     public:
-        Constant(const std::string& name = "",
+        explicit Constant(const std::string& name = "",
                 scalar value = fl::nan);
         virtual ~Constant() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Constant)

--- a/fuzzylite/fl/term/Cosine.h
+++ b/fuzzylite/fl/term/Cosine.h
@@ -33,7 +33,7 @@ namespace fl {
     protected:
         scalar _center, _width;
     public:
-        Cosine(const std::string& name = "",
+        explicit Cosine(const std::string& name = "",
                 scalar center = fl::nan,
                 scalar width = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/Discrete.h
+++ b/fuzzylite/fl/term/Discrete.h
@@ -38,7 +38,7 @@ namespace fl {
     protected:
         std::vector<Pair> _xy;
     public:
-        Discrete(const std::string& name = "",
+        explicit Discrete(const std::string& name = "",
                 const std::vector<Pair>& xy = std::vector<Pair>(),
                 scalar height = 1.0);
         virtual ~Discrete() FL_IOVERRIDE;

--- a/fuzzylite/fl/term/Function.h
+++ b/fuzzylite/fl/term/Function.h
@@ -84,9 +84,9 @@ namespace fl {
             std::string variable;
             scalar value;
 
-            Node(Element* element, Node* left = fl::null, Node* right = fl::null);
-            Node(const std::string& variable);
-            Node(scalar value);
+            explicit Node(Element* element, Node* left = fl::null, Node* right = fl::null);
+            explicit Node(const std::string& variable);
+            explicit Node(scalar value);
             Node(const Node& source);
             Node& operator=(const Node& rhs);
             virtual ~Node();
@@ -118,7 +118,7 @@ namespace fl {
         const Engine* _engine;
     public:
         mutable std::map<std::string, scalar> variables;
-        Function(const std::string& name = "",
+        explicit Function(const std::string& name = "",
                 const std::string& formula = "", const Engine* engine = fl::null);
         Function(const Function& other);
         Function& operator=(const Function& other);

--- a/fuzzylite/fl/term/Gaussian.h
+++ b/fuzzylite/fl/term/Gaussian.h
@@ -35,7 +35,7 @@ namespace fl {
         scalar _standardDeviation;
 
     public:
-        Gaussian(const std::string& name = "",
+        explicit Gaussian(const std::string& name = "",
                 scalar mean = fl::nan,
                 scalar standardDeviation = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/GaussianProduct.h
+++ b/fuzzylite/fl/term/GaussianProduct.h
@@ -37,7 +37,7 @@ namespace fl {
         scalar _standardDeviationB;
 
     public:
-        GaussianProduct(const std::string& name = "",
+        explicit GaussianProduct(const std::string& name = "",
                 scalar meanA = fl::nan,
                 scalar standardDeviationA = fl::nan,
                 scalar meanB = fl::nan,

--- a/fuzzylite/fl/term/Linear.h
+++ b/fuzzylite/fl/term/Linear.h
@@ -35,7 +35,7 @@ namespace fl {
         std::vector<scalar> _coefficients;
         const Engine* _engine;
     public:
-        Linear(const std::string& name = "",
+        explicit Linear(const std::string& name = "",
                 const std::vector<scalar>& coefficients = std::vector<scalar>(),
                 const Engine* engine = fl::null);
         virtual ~Linear() FL_IOVERRIDE;

--- a/fuzzylite/fl/term/PiShape.h
+++ b/fuzzylite/fl/term/PiShape.h
@@ -37,7 +37,7 @@ namespace fl {
         scalar _bottomRight;
 
     public:
-        PiShape(const std::string& name = "",
+        explicit PiShape(const std::string& name = "",
                 scalar bottomLeft = fl::nan,
                 scalar topLeft = fl::nan,
                 scalar topRight = fl::nan,

--- a/fuzzylite/fl/term/Ramp.h
+++ b/fuzzylite/fl/term/Ramp.h
@@ -38,7 +38,7 @@ namespace fl {
         enum Direction {
             POSITIVE, ZERO, NEGATIVE
         };
-        Ramp(const std::string& name = "",
+        explicit Ramp(const std::string& name = "",
                 scalar start = fl::nan,
                 scalar end = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/Rectangle.h
+++ b/fuzzylite/fl/term/Rectangle.h
@@ -34,7 +34,7 @@ namespace fl {
         scalar _start, _end;
 
     public:
-        Rectangle(const std::string& name = "",
+        explicit Rectangle(const std::string& name = "",
                 scalar start = fl::nan,
                 scalar end = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/SShape.h
+++ b/fuzzylite/fl/term/SShape.h
@@ -35,7 +35,7 @@ namespace fl {
         scalar _start, _end;
 
     public:
-        SShape(const std::string& name = "",
+        explicit SShape(const std::string& name = "",
                 scalar start = fl::nan,
                 scalar end = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/Sigmoid.h
+++ b/fuzzylite/fl/term/Sigmoid.h
@@ -38,7 +38,7 @@ namespace fl {
         enum Direction {
             POSITIVE, ZERO, NEGATIVE
         };
-        Sigmoid(const std::string& name = "",
+        explicit Sigmoid(const std::string& name = "",
                 scalar inflection = fl::nan,
                 scalar slope = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/SigmoidDifference.h
+++ b/fuzzylite/fl/term/SigmoidDifference.h
@@ -37,7 +37,7 @@ namespace fl {
         scalar _right;
 
     public:
-        SigmoidDifference(const std::string& name = "",
+        explicit SigmoidDifference(const std::string& name = "",
                 scalar left = fl::nan,
                 scalar rising = fl::nan,
                 scalar falling = fl::nan,

--- a/fuzzylite/fl/term/SigmoidProduct.h
+++ b/fuzzylite/fl/term/SigmoidProduct.h
@@ -37,7 +37,7 @@ namespace fl {
         scalar _right;
 
     public:
-        SigmoidProduct(const std::string& name = "",
+        explicit SigmoidProduct(const std::string& name = "",
                 scalar left = fl::nan,
                 scalar rising = fl::nan,
                 scalar falling = fl::nan,

--- a/fuzzylite/fl/term/Spike.h
+++ b/fuzzylite/fl/term/Spike.h
@@ -33,7 +33,7 @@ namespace fl {
     protected:
         scalar _center, _width;
     public:
-        Spike(const std::string& name = "",
+        explicit Spike(const std::string& name = "",
                 scalar center = fl::nan,
                 scalar width = fl::nan,
                 scalar height = 1.0);

--- a/fuzzylite/fl/term/Term.h
+++ b/fuzzylite/fl/term/Term.h
@@ -43,7 +43,7 @@ namespace fl {
         scalar _height;
     public:
 
-        Term(const std::string& name = "", scalar height = 1.0);
+        explicit Term(const std::string& name = "", scalar height = 1.0);
         virtual ~Term();
         FL_DEFAULT_COPY_AND_MOVE(Term)
 

--- a/fuzzylite/fl/term/Trapezoid.h
+++ b/fuzzylite/fl/term/Trapezoid.h
@@ -33,7 +33,7 @@ namespace fl {
     protected:
         scalar _vertexA, _vertexB, _vertexC, _vertexD;
     public:
-        Trapezoid(const std::string& name = "",
+        explicit Trapezoid(const std::string& name = "",
                 scalar vertexA = fl::nan,
                 scalar vertexB = fl::nan,
                 scalar vertexC = fl::nan,

--- a/fuzzylite/fl/term/Triangle.h
+++ b/fuzzylite/fl/term/Triangle.h
@@ -35,7 +35,7 @@ namespace fl {
         scalar _vertexB;
         scalar _vertexC;
     public:
-        Triangle(const std::string& name = "",
+        explicit Triangle(const std::string& name = "",
                 scalar vertexA = fl::nan,
                 scalar vertexB = fl::nan,
                 scalar vertexC = fl::nan,

--- a/fuzzylite/fl/term/ZShape.h
+++ b/fuzzylite/fl/term/ZShape.h
@@ -34,7 +34,7 @@ namespace fl {
         scalar _start, _end;
 
     public:
-        ZShape(const std::string& name = "",
+        explicit ZShape(const std::string& name = "",
                 scalar _start = fl::nan,
                 scalar _end = fl::nan,
                 scalar _height = 1.0);

--- a/fuzzylite/fl/variable/InputVariable.h
+++ b/fuzzylite/fl/variable/InputVariable.h
@@ -33,7 +33,7 @@ namespace fl {
     protected:
         scalar _inputValue;
     public:
-        InputVariable(const std::string& name = "",
+        explicit InputVariable(const std::string& name = "",
                 scalar minimum = -fl::inf,
                 scalar maximum = fl::inf);
         virtual ~InputVariable() FL_IOVERRIDE;

--- a/fuzzylite/fl/variable/OutputVariable.h
+++ b/fuzzylite/fl/variable/OutputVariable.h
@@ -44,7 +44,7 @@ namespace fl {
         bool _lockPreviousOutputValue;
 
     public:
-        OutputVariable(const std::string& name = "",
+        explicit OutputVariable(const std::string& name = "",
                 scalar minimum = -fl::inf, scalar maximum = fl::inf);
         OutputVariable(const OutputVariable& other);
         OutputVariable& operator=(const OutputVariable& other);

--- a/fuzzylite/fl/variable/Variable.h
+++ b/fuzzylite/fl/variable/Variable.h
@@ -45,7 +45,7 @@ namespace fl {
         bool _enabled;
 
     public:
-        Variable(const std::string& name = "",
+        explicit Variable(const std::string& name = "",
                 scalar minimum = -fl::inf,
                 scalar maximum = fl::inf);
         Variable(const Variable& other);


### PR DESCRIPTION
Hello,

I've added the 'explicit' qualifier both to single-argument class constructors and to the ones with more - but optional - arguments.
This is somewhat 'pedantic' but in my opinion it will help to avoid unwanted behavior during the development phase, like:

``` c++
std::string name("foobar");
fl::Engine engine = name;
```

The code above can be successfully compiled _without_ this patch, and it won't _with_ this path.

Can you consider to merge this pull request?

Thank you very much.

Sincerely,

-- Marco
