### PR TITLE
Moved template definitions in header files

### DIFF
--- a/fuzzylite/fl/factory/ConstructionFactory.h
+++ b/fuzzylite/fl/factory/ConstructionFactory.h
@@ -25,6 +25,7 @@
 #ifndef FL_FACTORY_H
 #define FL_FACTORY_H
 
+#include "fl/Exception.h"
 #include "fl/fuzzylite.h"
 
 #include <map>
@@ -43,19 +44,66 @@ namespace fl {
         std::map<std::string, Constructor> _constructors;
 
     public:
-        explicit ConstructionFactory(const std::string& name);
-        virtual ~ConstructionFactory();
+        explicit ConstructionFactory(const std::string& name)
+        : _name(name)
+        {
+        }
+
+        virtual ~ConstructionFactory() {
+        }
+
         FL_DEFAULT_COPY_AND_MOVE(ConstructionFactory)
 
-        virtual std::string name() const;
+        virtual std::string name() const {
+            return _name;
+        }
 
-        virtual void registerConstructor(const std::string& key, Constructor constructor);
-        virtual void deregisterConstructor(const std::string& key);
-        virtual bool hasConstructor(const std::string& key) const;
-        virtual Constructor getConstructor(const std::string& key) const;
-        virtual T constructObject(const std::string& key) const;
-        virtual std::vector<std::string> available() const;
+        virtual void registerConstructor(const std::string& key, Constructor constructor) {
+            _constructors[key] = constructor;
+        }
 
+        virtual void deregisterConstructor(const std::string& key) {
+            typename std::map<std::string, Constructor>::iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                this->_constructors.erase(it);
+            }
+        }
+
+        virtual bool hasConstructor(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            return (it != this->_constructors.end());
+        }
+
+        virtual Constructor getConstructor(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                return it->second;
+            }
+            return fl::null;
+        }
+
+        virtual T constructObject(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                if (it->second) {
+                    return it->second();
+                }
+                return fl::null;
+            }
+            std::ostringstream ss;
+            ss << "[factory error] constructor of " + _name + " <" << key << "> not registered";
+            throw fl::Exception(ss.str(), FL_AT);
+        }
+
+        virtual std::vector<std::string> available() const {
+            std::vector<std::string> result;
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.begin();
+            while (it != this->_constructors.end()) {
+                result.push_back(it->first);
+                ++it;
+            }
+            return result;
+        }
     };
 
 }

--- a/fuzzylite/fl/term/Linear.h
+++ b/fuzzylite/fl/term/Linear.h
@@ -25,7 +25,14 @@
 #ifndef FL_LINEAR_H
 #define FL_LINEAR_H
 
+#include "fl/Engine.h"
+#include "fl/Exception.h"
 #include "fl/term/Term.h"
+
+#include <cstdarg>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace fl {
     class Engine;
@@ -63,7 +70,21 @@ namespace fl {
         //Warning: this method is unsafe, make sure you use it correctly.
         template <typename T>
         static Linear* create(const std::string& name, const Engine* engine,
-                T firstCoefficient, ...); // throw (fl::Exception);
+                T firstCoefficient, ...) { // throw (fl::Exception);
+            if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
+                    "without a reference to the engine", FL_AT);
+            std::vector<scalar> coefficients;
+            coefficients.push_back(firstCoefficient);
+
+            std::va_list args;
+            va_start(args, firstCoefficient);
+            for (std::size_t i = 0; i < engine->inputVariables().size(); ++i) {
+                coefficients.push_back((scalar) va_arg(args, T));
+            }
+            va_end(args);
+
+            return new Linear(name, coefficients, engine);
+        }
     };
 
 }

--- a/fuzzylite/src/Operation.cpp
+++ b/fuzzylite/src/Operation.cpp
@@ -30,68 +30,16 @@
 #include "fl/norm/TNorm.h"
 
 #include <algorithm>
-#include <iomanip>
-#include <cstdarg>
 #include <cctype>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>
+#include <exception>
+#include <string>
+#include <sstream>
+#include <vector>
 
 namespace fl {
-
-    template <typename T>
-    T Operation::min(T a, T b) {
-        if (isNaN(a)) return b;
-        if (isNaN(b)) return a;
-        return a < b ? a : b;
-    }
-    template FL_API scalar Operation::min(scalar a, scalar b);
-    template FL_API int Operation::min(int a, int b);
-
-    template <typename T>
-    T Operation::max(T a, T b) {
-        if (isNaN(a)) return b;
-        if (isNaN(b)) return a;
-        return a > b ? a : b;
-    }
-    template FL_API scalar Operation::max(scalar a, scalar b);
-    template FL_API int Operation::max(int a, int b);
-
-    template <typename T>
-    T Operation::bound(T x, T min, T max) {
-        if (isGt(x, max)) return max;
-        if (isLt(x, min)) return min;
-        return x;
-    }
-    template FL_API scalar Operation::bound(scalar x, scalar min, scalar max);
-    template FL_API int Operation::bound(int x, int min, int max);
-
-    template <typename T>
-    bool Operation::in(T x, T min, T max, bool geq, bool leq) {
-        bool left = geq ? isGE(x, min) : isGt(x, min);
-        bool right = leq ? isLE(x, max) : isLt(x, max);
-        return (left and right);
-    }
-    template FL_API bool Operation::in(scalar x, scalar min, scalar max, bool geq, bool leq);
-    template FL_API bool Operation::in(int x, int min, int max, bool geq, bool leq);
-
-    template <typename T>
-    bool Operation::isInf(T x) {
-        return std::abs(x) == fl::inf;
-    }
-    template FL_API bool Operation::isInf(int x);
-    template FL_API bool Operation::isInf(scalar x);
-
-    template <typename T>
-    bool Operation::isNaN(T x) {
-        return not (x == x);
-    }
-    template FL_API bool Operation::isNaN(int x);
-    template FL_API bool Operation::isNaN(scalar x);
-
-    template<typename T>
-    bool Operation::isFinite(T x) {
-        return not (isNaN(x) or isInf(x));
-    }
-    template FL_API bool Operation::isFinite(int x);
-    template FL_API bool Operation::isFinite(scalar x);
 
     bool Operation::isLt(scalar a, scalar b, scalar macheps) {
         return not isEq(a, b, macheps) and a < b;
@@ -377,46 +325,12 @@ namespace fl {
         }
     }
 
-    template <typename T>
-    std::string Operation::str(T x, int decimals) {
-        std::ostringstream ss;
-        ss << std::setprecision(decimals) << std::fixed;
-        if (fl::Op::isNaN(x)) {
-            ss << "nan";
-        } else if (fl::Op::isInf(x)) {
-            if (fl::Op::isLt(x, 0.0)) ss << "-";
-            ss << "inf";
-        } else if (fl::Op::isEq(x, 0.0)) {
-            ss << std::fabs((x * 0.0)); //believe it or not, -1.33227e-15 * 0.0 = -0.0
-        } else ss << x;
-        return ss.str();
-    }
-    template FL_API std::string Operation::str(int x, int precision);
-    template FL_API std::string Operation::str(scalar x, int precision);
-
-    template <> FL_API std::string Operation::str(const std::string& x, int precision) {
+    std::string Operation::str(const std::string& x, int precision) {
         (void) precision;
         return x;
     }
 
-    template <typename T>
-    std::string Operation::join(const std::vector<T>& x,
-            const std::string& separator) {
-        std::ostringstream ss;
-        for (std::size_t i = 0; i < x.size(); ++i) {
-            ss << str(x.at(i));
-            if (i + 1 < x.size()) ss << separator;
-        }
-        return ss.str();
-    }
-    template FL_API std::string Operation::join(const std::vector<int>& x,
-            const std::string& separator);
-    template FL_API std::string Operation::join(const std::vector<scalar>& x,
-            const std::string& separator);
-
-    template <> FL_API
-    std::string Operation::join(const std::vector<std::string>& x,
-            const std::string& separator) {
+    std::string Operation::join(const std::vector<std::string>& x, const std::string& separator) {
         std::ostringstream ss;
         for (std::size_t i = 0; i < x.size(); ++i) {
             ss << x.at(i);
@@ -425,32 +339,11 @@ namespace fl {
         return ss.str();
     }
 
-    template <typename T>
-    std::string Operation::join(int items, const std::string& separator, T first, ...) {
+    std::string Operation::join(int items, const std::string& separator, float first, ...) {
         std::ostringstream ss;
         ss << str(first);
         if (items > 1) ss << separator;
-        va_list args;
-        va_start(args, first);
-        for (int i = 0; i < items - 1; ++i) {
-            ss << str(va_arg(args, T));
-            if (i + 1 < items - 1) ss << separator;
-        }
-        va_end(args);
-        return ss.str();
-    }
-
-    template FL_API std::string Operation::join(int items, const std::string& separator,
-            int first, ...);
-    template FL_API std::string Operation::join(int items, const std::string& separator,
-            double first, ...);
-
-    template <> FL_API std::string Operation::join(int items, const std::string& separator,
-            float first, ...) {
-        std::ostringstream ss;
-        ss << str(first);
-        if (items > 1) ss << separator;
-        va_list args;
+        std::va_list args;
         va_start(args, first);
         for (int i = 0; i < items - 1; ++i) {
             ss << str(va_arg(args, double)); //automatic promotion
@@ -460,12 +353,11 @@ namespace fl {
         return ss.str();
     }
 
-    template <> FL_API
     std::string Operation::join(int items, const std::string& separator, const char* first, ...) {
         std::ostringstream ss;
         ss << first;
         if (items > 1) ss << separator;
-        va_list args;
+        std::va_list args;
         va_start(args, first);
         for (int i = 0; i < items - 1; ++i) {
             ss << va_arg(args, const char*);
@@ -474,5 +366,4 @@ namespace fl {
         va_end(args);
         return ss.str();
     }
-
 }

--- a/fuzzylite/src/factory/CloningFactory.cpp
+++ b/fuzzylite/src/factory/CloningFactory.cpp
@@ -22,6 +22,8 @@
 
  */
 
+/*FIXME: THIS FILE COULD BE REMOVED
+
 #include "fl/factory/CloningFactory.h"
 
 #include "fl/Exception.h"
@@ -131,5 +133,6 @@ namespace fl {
 
     template class fl::CloningFactory<fl::Function::Element*>;
 }
+*/
 
 

--- a/fuzzylite/src/factory/ConstructionFactory.cpp
+++ b/fuzzylite/src/factory/ConstructionFactory.cpp
@@ -22,6 +22,9 @@
 
  */
 
+
+/*FIXME: THIS FILE COULD BE REMOVED
+
 #include "fl/factory/ConstructionFactory.h"
 
 #include "fl/Exception.h"
@@ -109,6 +112,6 @@ namespace fl {
     template class ConstructionFactory<TNorm*>;
     template class ConstructionFactory<Term*>;
 }
-
+*/
 
 

--- a/fuzzylite/src/term/Linear.cpp
+++ b/fuzzylite/src/term/Linear.cpp
@@ -25,9 +25,12 @@
 #include "fl/term/Linear.h"
 
 #include "fl/Engine.h"
+#include "fl/Exception.h"
 #include "fl/variable/InputVariable.h"
 
-#include <cstdarg>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace fl {
 
@@ -106,30 +109,4 @@ namespace fl {
     Term* Linear::constructor() {
         return new Linear;
     }
-
-    template <typename T>
-    Linear* Linear::create(const std::string& name,
-            const Engine* engine, T firstCoefficient, ...) {// throw (fl::Exception) {
-        if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
-                "without a reference to the engine", FL_AT);
-        std::vector<scalar> coefficients;
-        coefficients.push_back(firstCoefficient);
-
-        va_list args;
-        va_start(args, firstCoefficient);
-        for (std::size_t i = 0; i < engine->inputVariables().size(); ++i) {
-            coefficients.push_back((scalar) va_arg(args, T));
-        }
-        va_end(args);
-
-        return new Linear(name, coefficients, engine);
-    }
-
-    template FL_API Linear* Linear::create(const std::string& name,
-            const Engine* engine,
-            double firstCoefficient, ...);
-
-    template FL_API Linear* Linear::create(const std::string& name,
-            const Engine* engine,
-            int firstCoefficient, ...);
 }


### PR DESCRIPTION
Hi,

I moved class/methods template definitions into header files since the ISO C++ Standard mandates that templates must be inlined and hence they must be defined in the same place where they are declared (i.e., "A template-declaration is a declaration. A template-declaration is also a definition if its
declaration defines a function, a class, or a static data member." [1, ch. 14]).

Note, files `src/factory/ConstructionFactory.cpp` and `src/factory/CloningFactory.cpp`, in principle, could be removed. I'ven't done it by myself since I would have to change `cmake` files. But, unfortunately, I'm not familiar with `cmake`...

The changed files compile fine with GCC 4.9.2 under Fedora Linux x86_64.
Unfortunately, I don't have the opportunity to test with other compilers and under other operating systems.

Can you consider to merge this commit?

Best,

-- Marco

References:
1. ISO, *ISO/IEC 14882-2014: Information technology -- Programming languages -- C++*, 2014, URL of last Working Draft: http://open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3797.pdf