### PR TITLE
Moved template definitions in header files (reloaded)

### DIFF
--- a/fuzzylite/fl/Operation.h
+++ b/fuzzylite/fl/Operation.h
@@ -45,47 +45,25 @@ namespace fl {
     public:
 
         template <typename T>
-        static T min(T a, T b) {
-            if (isNaN(a)) return b;
-            if (isNaN(b)) return a;
-            return a < b ? a : b;
-        }
+        static T min(T a, T b);
 
         template <typename T>
-        static T max(T a, T b) {
-            if (isNaN(a)) return b;
-            if (isNaN(b)) return a;
-            return a > b ? a : b;
-        }
+        static T max(T a, T b);
 
         template <typename T>
-        static T bound(T x, T min, T max) {
-            if (isGt(x, max)) return max;
-            if (isLt(x, min)) return min;
-            return x;
-        }
+        static T bound(T x, T min, T max);
 
         template <typename T>
-        static bool in(T x, T min, T max, bool geq = true, bool leq = true) {
-            bool left = geq ? isGE(x, min) : isGt(x, min);
-            bool right = leq ? isLE(x, max) : isLt(x, max);
-            return (left and right);
-        }
+        static bool in(T x, T min, T max, bool geq = true, bool leq = true);
 
         template <typename T>
-        static bool isInf(T x) {
-            return std::abs(x) == fl::inf;
-        }
+        static bool isInf(T x);
 
         template <typename T>
-        static bool isNaN(T x) {
-            return not (x == x);
-        }
+        static bool isNaN(T x);
 
         template <typename T>
-        static bool isFinite(T x) {
-            return not (isNaN(x) or isInf(x));
-        }
+        static bool isFinite(T x);
 
         //Is less than
 
@@ -158,49 +136,18 @@ namespace fl {
         static bool isNumeric(const std::string& x);
 
         template <typename T>
-        static std::string str(T x, int decimals = fuzzylite::decimals()) {
-            std::ostringstream ss;
-            ss << std::setprecision(decimals) << std::fixed;
-            if (isNaN(x)) {
-                ss << "nan";
-            } else if (isInf(x)) {
-                if (isLt(x, 0.0)) ss << "-";
-                ss << "inf";
-            } else if (isEq(x, 0.0)) {
-                ss << std::fabs((x * 0.0)); //believe it or not, -1.33227e-15 * 0.0 = -0.0
-            } else ss << x;
-            return ss.str();
-        }
+        static std::string str(T x, int decimals = fuzzylite::decimals());
 
         static std::string str(const std::string& x, int precision);
 
         template <typename T>
-        static std::string join(const std::vector<T>& x, const std::string& separator) {
-            std::ostringstream ss;
-            for (std::size_t i = 0; i < x.size(); ++i) {
-                ss << str(x.at(i));
-                if (i + 1 < x.size()) ss << separator;
-            }
-            return ss.str();
-        }
+        static std::string join(const std::vector<T>& x, const std::string& separator);
 
         static std::string join(const std::vector<std::string>& x, const std::string& separator);
 
 
         template <typename T>
-        static std::string join(int items, const std::string& separator, T first, ...) {
-            std::ostringstream ss;
-            ss << str(first);
-            if (items > 1) ss << separator;
-            std::va_list args;
-            va_start(args, first);
-            for (int i = 0; i < items - 1; ++i) {
-                ss << str(va_arg(args, T));
-                if (i + 1 < items - 1) ss << separator;
-            }
-            va_end(args);
-            return ss.str();
-        }
+        static std::string join(int items, const std::string& separator, T first, ...);
 
         static std::string join(int items, const std::string& separator, float first, ...);
 
@@ -209,5 +156,8 @@ namespace fl {
 
     typedef Operation Op;
 }
+
+#include "fl/Operation.tpp"
+
 #endif  /* FL_OPERATION_H */
 

--- a/fuzzylite/fl/Operation.tpp
+++ b/fuzzylite/fl/Operation.tpp
@@ -1,0 +1,122 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+
+ */
+
+/**
+ * \file fl/Operation.tpp
+ *
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly.
+ */
+
+#ifndef FL_OPERATION_TPP
+#define FL_OPERATION_TPP
+
+namespace fl {
+
+template <typename T>
+T Operation::min(T a, T b) {
+    if (isNaN(a)) return b;
+    if (isNaN(b)) return a;
+    return a < b ? a : b;
+}
+
+template <typename T>
+T Operation::max(T a, T b) {
+    if (isNaN(a)) return b;
+    if (isNaN(b)) return a;
+    return a > b ? a : b;
+}
+
+template <typename T>
+T Operation::bound(T x, T min, T max) {
+    if (isGt(x, max)) return max;
+    if (isLt(x, min)) return min;
+    return x;
+}
+
+template <typename T>
+bool Operation::in(T x, T min, T max, bool geq, bool leq) {
+    bool left = geq ? isGE(x, min) : isGt(x, min);
+    bool right = leq ? isLE(x, max) : isLt(x, max);
+    return (left and right);
+}
+
+template <typename T>
+bool Operation::isInf(T x) {
+    return std::abs(x) == fl::inf;
+}
+
+template <typename T>
+bool Operation::isNaN(T x) {
+    return not (x == x);
+}
+
+template <typename T>
+bool Operation::isFinite(T x) {
+    return not (isNaN(x) or isInf(x));
+}
+
+template <typename T>
+std::string Operation::str(T x, int decimals) {
+    std::ostringstream ss;
+    ss << std::setprecision(decimals) << std::fixed;
+    if (isNaN(x)) {
+        ss << "nan";
+    } else if (isInf(x)) {
+        if (isLt(x, 0.0)) ss << "-";
+        ss << "inf";
+    } else if (isEq(x, 0.0)) {
+        ss << std::fabs((x * 0.0)); //believe it or not, -1.33227e-15 * 0.0 = -0.0
+    } else ss << x;
+    return ss.str();
+}
+
+template <typename T>
+std::string Operation::join(const std::vector<T>& x, const std::string& separator) {
+    std::ostringstream ss;
+    for (std::size_t i = 0; i < x.size(); ++i) {
+        ss << str(x.at(i));
+        if (i + 1 < x.size()) ss << separator;
+    }
+    return ss.str();
+}
+
+template <typename T>
+std::string Operation::join(int items, const std::string& separator, T first, ...) {
+    std::ostringstream ss;
+    ss << str(first);
+    if (items > 1) ss << separator;
+    std::va_list args;
+    va_start(args, first);
+    for (int i = 0; i < items - 1; ++i) {
+        ss << str(va_arg(args, T));
+        if (i + 1 < items - 1) ss << separator;
+    }
+    va_end(args);
+    return ss.str();
+}
+
+} // Namespace fl
+
+#endif // FL_OPERATION_TPP

--- a/fuzzylite/fl/factory/CloningFactory.h
+++ b/fuzzylite/fl/factory/CloningFactory.h
@@ -42,103 +42,33 @@ namespace fl {
         std::map<std::string, T> _objects;
 
     public:
-        explicit CloningFactory(const std::string& name = "")
-        : _name(name)
-        {
-        }
+        explicit CloningFactory(const std::string& name = "");
 
-        CloningFactory(const CloningFactory& other)
-        : _name(other._name)
-        {
-            typename std::map<std::string, T>::const_iterator it = other._objects.begin();
-            while (it != other._objects.end()) {
-                T clone = fl::null;
-                if (it->second) clone = it->second->clone();
-                this->_objects[it->first] = clone;
-                ++it;
-            }
-        }
+        CloningFactory(const CloningFactory& other);
 
-        CloningFactory& operator=(const CloningFactory& other) {
-            if (this != &other) {
-                _name = other._name;
+        CloningFactory& operator=(const CloningFactory& other);
 
-                typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
-                while (it != this->_objects.end()) {
-                    if (it->second) delete it->second;
-                    ++it;
-                }
-                this->_objects.clear();
-
-                it = other._objects.begin();
-                while (it != other._objects.end()) {
-                    T clone = fl::null;
-                    if (it->second) clone = it->second->clone();
-                    this->_objects[it->first] = clone;
-                    ++it;
-                }
-            }
-            return *this;
-        }
-
-        virtual ~CloningFactory() {
-            typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
-            while (it != this->_objects.end()) {
-                if (it->second) delete it->second;
-                ++it;
-            }
-        }
+        virtual ~CloningFactory();
 
         FL_DEFAULT_MOVE(CloningFactory)
 
-        virtual std::string name() const {
-            return _name;
-        }
+        virtual std::string name() const;
 
-        virtual void registerObject(const std::string& key, T object) {
-            _objects[key] = object;
-        }
+        virtual void registerObject(const std::string& key, T object);
 
-        virtual void deregisterObject(const std::string& key) {
-            typename std::map<std::string, T>::iterator it = this->_objects.find(key);
-            if (it != this->_objects.end()) {
-                this->_objects.erase(it);
-                delete it->second;
-            }
-        }
+        virtual void deregisterObject(const std::string& key);
 
-        virtual bool hasObject(const std::string& key) const {
-            typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
-            return (it != this->_objects.end());
-        }
+        virtual bool hasObject(const std::string& key) const;
 
-        virtual T getObject(const std::string& key) const {
-            typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
-            if (it != this->_objects.end()) {
-                if (it->second) return it->second;
-            }
-            return fl::null;
-        }
+        virtual T getObject(const std::string& key) const;
 
-        virtual T cloneObject(const std::string& key) const {
-            typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
-            if (it != this->_objects.end()) {
-                if (it->second) return it->second->clone();
-                return fl::null;
-            }
-            throw fl::Exception("[cloning error] " + _name + " object by name <" + key + "> not registered", FL_AT);
-        }
+        virtual T cloneObject(const std::string& key) const;
 
-        virtual std::vector<std::string> available() const {
-            std::vector<std::string> result;
-            typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
-            while (it != this->_objects.end()) {
-                result.push_back(it->first);
-            }
-            return result;
-        }
+        virtual std::vector<std::string> available() const;
     };
 }
+
+#include "fl/factory/CloningFactory.tpp"
 
 #endif  /* FL_CLONINGFACTORY_H */
 

--- a/fuzzylite/fl/factory/CloningFactory.tpp
+++ b/fuzzylite/fl/factory/CloningFactory.tpp
@@ -1,0 +1,146 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+
+ */
+
+/**
+ * \file fl/factory/CloningnFactory.tpp
+ *
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly.
+ */
+
+#ifndef FL_CLONINGFACTORY_TPP
+#define FL_CLONINGFACTORY_TPP
+
+
+namespace fl {
+
+template <typename T>
+CloningFactory<T>::CloningFactory(const std::string& name)
+: _name(name)
+{
+}
+
+template <typename T>
+CloningFactory<T>::CloningFactory(const CloningFactory<T>& other)
+: _name(other._name)
+{
+    typename std::map<std::string, T>::const_iterator it = other._objects.begin();
+    while (it != other._objects.end()) {
+        T clone = fl::null;
+        if (it->second) clone = it->second->clone();
+        this->_objects[it->first] = clone;
+        ++it;
+    }
+}
+
+template <typename T>
+CloningFactory<T>& CloningFactory<T>::operator=(const CloningFactory<T>& other) {
+    if (this != &other) {
+        _name = other._name;
+
+        typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
+        while (it != this->_objects.end()) {
+            if (it->second) delete it->second;
+            ++it;
+        }
+        this->_objects.clear();
+
+        it = other._objects.begin();
+        while (it != other._objects.end()) {
+            T clone = fl::null;
+            if (it->second) clone = it->second->clone();
+            this->_objects[it->first] = clone;
+            ++it;
+        }
+    }
+    return *this;
+}
+
+template <typename T>
+CloningFactory<T>::~CloningFactory() {
+    typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
+    while (it != this->_objects.end()) {
+        if (it->second) delete it->second;
+        ++it;
+    }
+}
+
+template <typename T>
+std::string CloningFactory<T>::name() const {
+    return _name;
+}
+
+template <typename T>
+void CloningFactory<T>::registerObject(const std::string& key, T object) {
+    _objects[key] = object;
+}
+
+template <typename T>
+void CloningFactory<T>::deregisterObject(const std::string& key) {
+    typename std::map<std::string, T>::iterator it = this->_objects.find(key);
+    if (it != this->_objects.end()) {
+        this->_objects.erase(it);
+        delete it->second;
+    }
+}
+
+template <typename T>
+bool CloningFactory<T>::hasObject(const std::string& key) const {
+    typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
+    return (it != this->_objects.end());
+}
+
+template <typename T>
+T CloningFactory<T>::getObject(const std::string& key) const {
+    typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
+    if (it != this->_objects.end()) {
+        if (it->second) return it->second;
+    }
+    return fl::null;
+}
+
+template <typename T>
+T CloningFactory<T>::cloneObject(const std::string& key) const {
+    typename std::map<std::string, T>::const_iterator it = this->_objects.find(key);
+    if (it != this->_objects.end()) {
+        if (it->second) return it->second->clone();
+        return fl::null;
+    }
+    throw fl::Exception("[cloning error] " + _name + " object by name <" + key + "> not registered", FL_AT);
+}
+
+template <typename T>
+std::vector<std::string> CloningFactory<T>::available() const {
+    std::vector<std::string> result;
+    typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
+    while (it != this->_objects.end()) {
+        result.push_back(it->first);
+    }
+    return result;
+}
+
+} // Namespace fl
+
+#endif // FL_CLONINGFACTORY_TPP
+

--- a/fuzzylite/fl/factory/ConstructionFactory.h
+++ b/fuzzylite/fl/factory/ConstructionFactory.h
@@ -44,69 +44,29 @@ namespace fl {
         std::map<std::string, Constructor> _constructors;
 
     public:
-        explicit ConstructionFactory(const std::string& name)
-        : _name(name)
-        {
-        }
+        explicit ConstructionFactory(const std::string& name);
 
-        virtual ~ConstructionFactory() {
-        }
+        virtual ~ConstructionFactory();
 
         FL_DEFAULT_COPY_AND_MOVE(ConstructionFactory)
 
-        virtual std::string name() const {
-            return _name;
-        }
+        virtual std::string name() const;
 
-        virtual void registerConstructor(const std::string& key, Constructor constructor) {
-            _constructors[key] = constructor;
-        }
+        virtual void registerConstructor(const std::string& key, Constructor constructor);
 
-        virtual void deregisterConstructor(const std::string& key) {
-            typename std::map<std::string, Constructor>::iterator it = this->_constructors.find(key);
-            if (it != this->_constructors.end()) {
-                this->_constructors.erase(it);
-            }
-        }
+        virtual void deregisterConstructor(const std::string& key);
 
-        virtual bool hasConstructor(const std::string& key) const {
-            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
-            return (it != this->_constructors.end());
-        }
+        virtual bool hasConstructor(const std::string& key) const;
 
-        virtual Constructor getConstructor(const std::string& key) const {
-            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
-            if (it != this->_constructors.end()) {
-                return it->second;
-            }
-            return fl::null;
-        }
+        virtual Constructor getConstructor(const std::string& key) const;
 
-        virtual T constructObject(const std::string& key) const {
-            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
-            if (it != this->_constructors.end()) {
-                if (it->second) {
-                    return it->second();
-                }
-                return fl::null;
-            }
-            std::ostringstream ss;
-            ss << "[factory error] constructor of " + _name + " <" << key << "> not registered";
-            throw fl::Exception(ss.str(), FL_AT);
-        }
+        virtual T constructObject(const std::string& key) const;
 
-        virtual std::vector<std::string> available() const {
-            std::vector<std::string> result;
-            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.begin();
-            while (it != this->_constructors.end()) {
-                result.push_back(it->first);
-                ++it;
-            }
-            return result;
-        }
+        virtual std::vector<std::string> available() const;
     };
-
 }
+
+#include "fl/factory/ConstructionFactory.tpp"
 
 #endif  /* FL_FACTORY_H */
 

--- a/fuzzylite/fl/factory/ConstructionFactory.h
+++ b/fuzzylite/fl/factory/ConstructionFactory.h
@@ -25,6 +25,7 @@
 #ifndef FL_FACTORY_H
 #define FL_FACTORY_H
 
+#include "fl/Exception.h"
 #include "fl/fuzzylite.h"
 
 #include <map>
@@ -43,19 +44,66 @@ namespace fl {
         std::map<std::string, Constructor> _constructors;
 
     public:
-        explicit ConstructionFactory(const std::string& name);
-        virtual ~ConstructionFactory();
+        explicit ConstructionFactory(const std::string& name)
+        : _name(name)
+        {
+        }
+
+        virtual ~ConstructionFactory() {
+        }
+
         FL_DEFAULT_COPY_AND_MOVE(ConstructionFactory)
 
-        virtual std::string name() const;
+        virtual std::string name() const {
+            return _name;
+        }
 
-        virtual void registerConstructor(const std::string& key, Constructor constructor);
-        virtual void deregisterConstructor(const std::string& key);
-        virtual bool hasConstructor(const std::string& key) const;
-        virtual Constructor getConstructor(const std::string& key) const;
-        virtual T constructObject(const std::string& key) const;
-        virtual std::vector<std::string> available() const;
+        virtual void registerConstructor(const std::string& key, Constructor constructor) {
+            _constructors[key] = constructor;
+        }
 
+        virtual void deregisterConstructor(const std::string& key) {
+            typename std::map<std::string, Constructor>::iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                this->_constructors.erase(it);
+            }
+        }
+
+        virtual bool hasConstructor(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            return (it != this->_constructors.end());
+        }
+
+        virtual Constructor getConstructor(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                return it->second;
+            }
+            return fl::null;
+        }
+
+        virtual T constructObject(const std::string& key) const {
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+            if (it != this->_constructors.end()) {
+                if (it->second) {
+                    return it->second();
+                }
+                return fl::null;
+            }
+            std::ostringstream ss;
+            ss << "[factory error] constructor of " + _name + " <" << key << "> not registered";
+            throw fl::Exception(ss.str(), FL_AT);
+        }
+
+        virtual std::vector<std::string> available() const {
+            std::vector<std::string> result;
+            typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.begin();
+            while (it != this->_constructors.end()) {
+                result.push_back(it->first);
+                ++it;
+            }
+            return result;
+        }
     };
 
 }

--- a/fuzzylite/fl/factory/ConstructionFactory.tpp
+++ b/fuzzylite/fl/factory/ConstructionFactory.tpp
@@ -1,0 +1,109 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+
+ */
+
+/**
+ * \file fl/factory/ConstructionFactory.tpp
+ *
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly.
+ */
+
+#ifndef FL_FACTORY_TPP
+#define FL_FACTORY_TPP
+
+
+namespace fl {
+
+template <typename T>
+ConstructionFactory<T>::ConstructionFactory(const std::string& name)
+: _name(name)
+{
+}
+
+template <typename T>
+ConstructionFactory<T>::~ConstructionFactory() {
+}
+
+template <typename T>
+std::string ConstructionFactory<T>::name() const {
+    return _name;
+}
+
+template <typename T>
+void ConstructionFactory<T>::registerConstructor(const std::string& key, typename ConstructionFactory<T>::Constructor constructor) {
+    _constructors[key] = constructor;
+}
+
+template <typename T>
+void ConstructionFactory<T>::deregisterConstructor(const std::string& key) {
+    typename std::map<std::string, Constructor>::iterator it = this->_constructors.find(key);
+    if (it != this->_constructors.end()) {
+        this->_constructors.erase(it);
+    }
+}
+
+template <typename T>
+bool ConstructionFactory<T>::hasConstructor(const std::string& key) const {
+    typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+    return (it != this->_constructors.end());
+}
+
+template <typename T>
+typename ConstructionFactory<T>::Constructor ConstructionFactory<T>::getConstructor(const std::string& key) const {
+    typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+    if (it != this->_constructors.end()) {
+        return it->second;
+    }
+    return fl::null;
+}
+
+template <typename T>
+T ConstructionFactory<T>::constructObject(const std::string& key) const {
+    typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.find(key);
+    if (it != this->_constructors.end()) {
+        if (it->second) {
+            return it->second();
+        }
+        return fl::null;
+    }
+    std::ostringstream ss;
+    ss << "[factory error] constructor of " + _name + " <" << key << "> not registered";
+    throw fl::Exception(ss.str(), FL_AT);
+}
+
+template <typename T>
+std::vector<std::string> ConstructionFactory<T>::available() const {
+    std::vector<std::string> result;
+    typename std::map<std::string, Constructor>::const_iterator it = this->_constructors.begin();
+    while (it != this->_constructors.end()) {
+        result.push_back(it->first);
+        ++it;
+    }
+    return result;
+}
+
+} // Namespace fl
+
+#endif // FL_FACTORY_TPP
+

--- a/fuzzylite/fl/term/Discrete.h
+++ b/fuzzylite/fl/term/Discrete.h
@@ -78,4 +78,7 @@ namespace fl {
     };
 
 }
+
+#include "fl/term/Discrete.tpp"
+
 #endif /* FL_DISCRETE_H */

--- a/fuzzylite/fl/term/Discrete.tpp
+++ b/fuzzylite/fl/term/Discrete.tpp
@@ -1,0 +1,61 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+
+ */
+
+/**
+ * \file fl/term/Discrete.tpp
+ *
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly.
+ */
+
+#ifndef FL_DISCRETE_TPP
+#define FL_DISCRETE_TPP
+
+namespace fl {
+
+template <typename T>
+Discrete* Discrete::create(const std::string& name, int argc,
+		T x1, T y1, ...) { // throw (fl::Exception) {
+	std::vector<scalar> xy(argc);
+	xy.at(0) = x1;
+	xy.at(1) = y1;
+	va_list args;
+	va_start(args, y1);
+	for (int i = 2; i < argc; ++i) {
+		xy.at(i) = (scalar) va_arg(args, T);
+	}
+	va_end(args);
+
+	FL_unique_ptr<Discrete> result(new Discrete(name));
+	if (xy.size() % 2 != 0) {
+		result->setHeight(xy.back());
+		xy.pop_back();
+	}
+	result->setXY(toPairs(xy));
+	return result.release();
+}
+
+} // Namespace fl
+
+#endif // FL_DISCRETE_TPP

--- a/fuzzylite/fl/term/Linear.h
+++ b/fuzzylite/fl/term/Linear.h
@@ -25,7 +25,14 @@
 #ifndef FL_LINEAR_H
 #define FL_LINEAR_H
 
+#include "fl/Engine.h"
+#include "fl/Exception.h"
 #include "fl/term/Term.h"
+
+#include <cstdarg>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace fl {
     class Engine;
@@ -63,7 +70,21 @@ namespace fl {
         //Warning: this method is unsafe, make sure you use it correctly.
         template <typename T>
         static Linear* create(const std::string& name, const Engine* engine,
-                T firstCoefficient, ...); // throw (fl::Exception);
+                T firstCoefficient, ...) { // throw (fl::Exception);
+            if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
+                    "without a reference to the engine", FL_AT);
+            std::vector<scalar> coefficients;
+            coefficients.push_back(firstCoefficient);
+
+            std::va_list args;
+            va_start(args, firstCoefficient);
+            for (std::size_t i = 0; i < engine->inputVariables().size(); ++i) {
+                coefficients.push_back((scalar) va_arg(args, T));
+            }
+            va_end(args);
+
+            return new Linear(name, coefficients, engine);
+        }
     };
 
 }

--- a/fuzzylite/fl/term/Linear.h
+++ b/fuzzylite/fl/term/Linear.h
@@ -70,7 +70,7 @@ namespace fl {
         //Warning: this method is unsafe, make sure you use it correctly.
         template <typename T>
         static Linear* create(const std::string& name, const Engine* engine,
-                T firstCoefficient, ...) { // throw (fl::Exception);
+                T firstCoefficient, ...); /* { // throw (fl::Exception);
             if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
                     "without a reference to the engine", FL_AT);
             std::vector<scalar> coefficients;
@@ -84,10 +84,12 @@ namespace fl {
             va_end(args);
 
             return new Linear(name, coefficients, engine);
-        }
+        }*/
     };
 
 }
+
+#include "fl/term/Linear.tpp"
 
 #endif  /* FL_LINEAR_H */
 

--- a/fuzzylite/fl/term/Linear.tpp
+++ b/fuzzylite/fl/term/Linear.tpp
@@ -1,0 +1,58 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+
+ */
+
+/**
+ * \file fl/term/Linear.tpp
+ *
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly.
+ */
+
+#ifndef FL_LINEAR_TPP
+#define FL_LINEAR_TPP
+
+namespace fl {
+
+//Warning: this method is unsafe, make sure you use it correctly.
+template <typename T>
+Linear* Linear::create(const std::string& name, const Engine* engine,
+        T firstCoefficient, ...) { // throw (fl::Exception);
+    if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
+            "without a reference to the engine", FL_AT);
+    std::vector<scalar> coefficients;
+    coefficients.push_back(firstCoefficient);
+
+    std::va_list args;
+    va_start(args, firstCoefficient);
+    for (std::size_t i = 0; i < engine->inputVariables().size(); ++i) {
+        coefficients.push_back((scalar) va_arg(args, T));
+    }
+    va_end(args);
+
+    return new Linear(name, coefficients, engine);
+}
+
+} // Namespace fl
+
+#endif // FL_LINEAR_TPP

--- a/fuzzylite/src/Operation.cpp
+++ b/fuzzylite/src/Operation.cpp
@@ -30,68 +30,16 @@
 #include "fl/norm/TNorm.h"
 
 #include <algorithm>
-#include <iomanip>
-#include <cstdarg>
 #include <cctype>
+#include <cmath>
+#include <cstdarg>
+#include <cstddef>
+#include <exception>
+#include <string>
+#include <sstream>
+#include <vector>
 
 namespace fl {
-
-    template <typename T>
-    T Operation::min(T a, T b) {
-        if (isNaN(a)) return b;
-        if (isNaN(b)) return a;
-        return a < b ? a : b;
-    }
-    template FL_API scalar Operation::min(scalar a, scalar b);
-    template FL_API int Operation::min(int a, int b);
-
-    template <typename T>
-    T Operation::max(T a, T b) {
-        if (isNaN(a)) return b;
-        if (isNaN(b)) return a;
-        return a > b ? a : b;
-    }
-    template FL_API scalar Operation::max(scalar a, scalar b);
-    template FL_API int Operation::max(int a, int b);
-
-    template <typename T>
-    T Operation::bound(T x, T min, T max) {
-        if (isGt(x, max)) return max;
-        if (isLt(x, min)) return min;
-        return x;
-    }
-    template FL_API scalar Operation::bound(scalar x, scalar min, scalar max);
-    template FL_API int Operation::bound(int x, int min, int max);
-
-    template <typename T>
-    bool Operation::in(T x, T min, T max, bool geq, bool leq) {
-        bool left = geq ? isGE(x, min) : isGt(x, min);
-        bool right = leq ? isLE(x, max) : isLt(x, max);
-        return (left and right);
-    }
-    template FL_API bool Operation::in(scalar x, scalar min, scalar max, bool geq, bool leq);
-    template FL_API bool Operation::in(int x, int min, int max, bool geq, bool leq);
-
-    template <typename T>
-    bool Operation::isInf(T x) {
-        return std::abs(x) == fl::inf;
-    }
-    template FL_API bool Operation::isInf(int x);
-    template FL_API bool Operation::isInf(scalar x);
-
-    template <typename T>
-    bool Operation::isNaN(T x) {
-        return not (x == x);
-    }
-    template FL_API bool Operation::isNaN(int x);
-    template FL_API bool Operation::isNaN(scalar x);
-
-    template<typename T>
-    bool Operation::isFinite(T x) {
-        return not (isNaN(x) or isInf(x));
-    }
-    template FL_API bool Operation::isFinite(int x);
-    template FL_API bool Operation::isFinite(scalar x);
 
     bool Operation::isLt(scalar a, scalar b, scalar macheps) {
         return not isEq(a, b, macheps) and a < b;
@@ -377,46 +325,12 @@ namespace fl {
         }
     }
 
-    template <typename T>
-    std::string Operation::str(T x, int decimals) {
-        std::ostringstream ss;
-        ss << std::setprecision(decimals) << std::fixed;
-        if (fl::Op::isNaN(x)) {
-            ss << "nan";
-        } else if (fl::Op::isInf(x)) {
-            if (fl::Op::isLt(x, 0.0)) ss << "-";
-            ss << "inf";
-        } else if (fl::Op::isEq(x, 0.0)) {
-            ss << std::fabs((x * 0.0)); //believe it or not, -1.33227e-15 * 0.0 = -0.0
-        } else ss << x;
-        return ss.str();
-    }
-    template FL_API std::string Operation::str(int x, int precision);
-    template FL_API std::string Operation::str(scalar x, int precision);
-
-    template <> FL_API std::string Operation::str(const std::string& x, int precision) {
+    std::string Operation::str(const std::string& x, int precision) {
         (void) precision;
         return x;
     }
 
-    template <typename T>
-    std::string Operation::join(const std::vector<T>& x,
-            const std::string& separator) {
-        std::ostringstream ss;
-        for (std::size_t i = 0; i < x.size(); ++i) {
-            ss << str(x.at(i));
-            if (i + 1 < x.size()) ss << separator;
-        }
-        return ss.str();
-    }
-    template FL_API std::string Operation::join(const std::vector<int>& x,
-            const std::string& separator);
-    template FL_API std::string Operation::join(const std::vector<scalar>& x,
-            const std::string& separator);
-
-    template <> FL_API
-    std::string Operation::join(const std::vector<std::string>& x,
-            const std::string& separator) {
+    std::string Operation::join(const std::vector<std::string>& x, const std::string& separator) {
         std::ostringstream ss;
         for (std::size_t i = 0; i < x.size(); ++i) {
             ss << x.at(i);
@@ -425,32 +339,11 @@ namespace fl {
         return ss.str();
     }
 
-    template <typename T>
-    std::string Operation::join(int items, const std::string& separator, T first, ...) {
+    std::string Operation::join(int items, const std::string& separator, float first, ...) {
         std::ostringstream ss;
         ss << str(first);
         if (items > 1) ss << separator;
-        va_list args;
-        va_start(args, first);
-        for (int i = 0; i < items - 1; ++i) {
-            ss << str(va_arg(args, T));
-            if (i + 1 < items - 1) ss << separator;
-        }
-        va_end(args);
-        return ss.str();
-    }
-
-    template FL_API std::string Operation::join(int items, const std::string& separator,
-            int first, ...);
-    template FL_API std::string Operation::join(int items, const std::string& separator,
-            double first, ...);
-
-    template <> FL_API std::string Operation::join(int items, const std::string& separator,
-            float first, ...) {
-        std::ostringstream ss;
-        ss << str(first);
-        if (items > 1) ss << separator;
-        va_list args;
+        std::va_list args;
         va_start(args, first);
         for (int i = 0; i < items - 1; ++i) {
             ss << str(va_arg(args, double)); //automatic promotion
@@ -460,12 +353,11 @@ namespace fl {
         return ss.str();
     }
 
-    template <> FL_API
     std::string Operation::join(int items, const std::string& separator, const char* first, ...) {
         std::ostringstream ss;
         ss << first;
         if (items > 1) ss << separator;
-        va_list args;
+        std::va_list args;
         va_start(args, first);
         for (int i = 0; i < items - 1; ++i) {
             ss << va_arg(args, const char*);
@@ -474,5 +366,4 @@ namespace fl {
         va_end(args);
         return ss.str();
     }
-
 }

--- a/fuzzylite/src/factory/CloningFactory.cpp
+++ b/fuzzylite/src/factory/CloningFactory.cpp
@@ -22,6 +22,8 @@
 
  */
 
+/*FIXME: THIS FILE COULD BE REMOVED
+
 #include "fl/factory/CloningFactory.h"
 
 #include "fl/Exception.h"
@@ -131,5 +133,6 @@ namespace fl {
 
     template class fl::CloningFactory<fl::Function::Element*>;
 }
+*/
 
 

--- a/fuzzylite/src/factory/ConstructionFactory.cpp
+++ b/fuzzylite/src/factory/ConstructionFactory.cpp
@@ -22,6 +22,9 @@
 
  */
 
+
+/*FIXME: THIS FILE COULD BE REMOVED
+
 #include "fl/factory/ConstructionFactory.h"
 
 #include "fl/Exception.h"
@@ -109,6 +112,6 @@ namespace fl {
     template class ConstructionFactory<TNorm*>;
     template class ConstructionFactory<Term*>;
 }
-
+*/
 
 

--- a/fuzzylite/src/term/Discrete.cpp
+++ b/fuzzylite/src/term/Discrete.cpp
@@ -102,34 +102,6 @@ namespace fl {
         this->_xy = toPairs(values);
     }
 
-    template <typename T>
-    Discrete* Discrete::create(const std::string& name, int argc,
-            T x1, T y1, ...) { // throw (fl::Exception) {
-        std::vector<scalar> xy(argc);
-        xy.at(0) = x1;
-        xy.at(1) = y1;
-        va_list args;
-        va_start(args, y1);
-        for (int i = 2; i < argc; ++i) {
-            xy.at(i) = (scalar) va_arg(args, T);
-        }
-        va_end(args);
-
-        FL_unique_ptr<Discrete> result(new Discrete(name));
-        if (xy.size() % 2 != 0) {
-            result->setHeight(xy.back());
-            xy.pop_back();
-        }
-        result->setXY(toPairs(xy));
-        return result.release();
-    }
-
-    template FL_API Discrete* Discrete::create(const std::string& name, int argc,
-            double x1, double y1, ...); // throw (fl::Exception);
-    //double, not scalar because variadic promotes floats to double
-    template FL_API Discrete* Discrete::create(const std::string& name, int argc,
-            int x1, int y1, ...); // throw (fl::Exception);
-
     void Discrete::setXY(const std::vector<Pair>& pairs) {
         this->_xy = pairs;
     }

--- a/fuzzylite/src/term/Linear.cpp
+++ b/fuzzylite/src/term/Linear.cpp
@@ -25,9 +25,12 @@
 #include "fl/term/Linear.h"
 
 #include "fl/Engine.h"
+#include "fl/Exception.h"
 #include "fl/variable/InputVariable.h"
 
-#include <cstdarg>
+#include <cstddef>
+#include <string>
+#include <vector>
 
 namespace fl {
 
@@ -106,30 +109,4 @@ namespace fl {
     Term* Linear::constructor() {
         return new Linear;
     }
-
-    template <typename T>
-    Linear* Linear::create(const std::string& name,
-            const Engine* engine, T firstCoefficient, ...) {// throw (fl::Exception) {
-        if (not engine) throw fl::Exception("[linear error] cannot create term <" + name + "> "
-                "without a reference to the engine", FL_AT);
-        std::vector<scalar> coefficients;
-        coefficients.push_back(firstCoefficient);
-
-        va_list args;
-        va_start(args, firstCoefficient);
-        for (std::size_t i = 0; i < engine->inputVariables().size(); ++i) {
-            coefficients.push_back((scalar) va_arg(args, T));
-        }
-        va_end(args);
-
-        return new Linear(name, coefficients, engine);
-    }
-
-    template FL_API Linear* Linear::create(const std::string& name,
-            const Engine* engine,
-            double firstCoefficient, ...);
-
-    template FL_API Linear* Linear::create(const std::string& name,
-            const Engine* engine,
-            int firstCoefficient, ...);
 }


### PR DESCRIPTION
Hi Juan,

I've moved template defs into separate `.tpp` header files (for the record, see pull request #22 ).

On Linux x86_64 with GCC 4.9.2, all compiles fine.

Also, as I previously said:

> Note, files `src/factory/ConstructionFactory.cpp and src/factory/CloningFactory.cpp`, in principle, could be removed. I'ven't done it by myself since I would have to change `cmake` files. But, unfortunately, I'm not familiar with `cmake`...

Let me know if there are other changes to do.

Cheers,

Marco