### PR TITLE
Changed signature of Engine::updateReferences

### DIFF
--- a/fuzzylite/fl/Engine.h
+++ b/fuzzylite/fl/Engine.h
@@ -52,7 +52,7 @@ namespace fl {
         std::vector<OutputVariable*> _outputVariables;
         std::vector<RuleBlock*> _ruleblocks;
 
-        void updateReferences() const;
+        virtual void updateReferences();
 
     public:
         explicit Engine(const std::string& name = "");

--- a/fuzzylite/src/Engine.cpp
+++ b/fuzzylite/src/Engine.cpp
@@ -94,7 +94,7 @@ namespace fl {
         }
     }
 
-    void Engine::updateReferences() const {
+    void Engine::updateReferences() {
         std::vector<Variable*> myVariables = variables();
         for (std::size_t i = 0; i < myVariables.size(); ++i) {
             Variable* variable = myVariables.at(i);


### PR DESCRIPTION
Hello,

Since I'm working to an extension (i.e., derived class) of the `Engine` class, I need that `Engine::updateReferences` be `virtual`.

Furthermore, the `const` specifier causes me some trouble. I've noted that if I remove it, the compilation is still OK.

Can you consider to merge this request?

Thank you.

Best,

Marco