### PR TITLE
Mark virtual functions as override

### DIFF
--- a/fuzzylite/fl/norm/SNorm.h
+++ b/fuzzylite/fl/norm/SNorm.h
@@ -40,7 +40,7 @@ namespace fl {
 
         FL_DEFAULT_COPY_AND_MOVE(SNorm)
 
-        virtual SNorm* clone() const = 0;
+        virtual SNorm* clone() const FL_IOVERRIDE = 0;
     };
 }
 #endif  /* FL_SNORM_H */

--- a/fuzzylite/fl/norm/TNorm.h
+++ b/fuzzylite/fl/norm/TNorm.h
@@ -40,7 +40,7 @@ namespace fl {
 
         FL_DEFAULT_COPY_AND_MOVE(TNorm)
 
-        virtual TNorm* clone() const = 0;
+        virtual TNorm* clone() const FL_IOVERRIDE = 0;
     };
 }
 #endif  /* TNORM_H */


### PR DESCRIPTION
This fixes clang 3.6 -Winconsistent-missing-override warnings:

    In file included from /tmp/fuzzylite/fuzzylite/src/variable/OutputVariable.cpp:29:
    /tmp/fuzzylite/fuzzylite/./fl/norm/SNorm.h:43:24: warning: 'clone' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
            virtual SNorm* clone() const = 0;
                           ^
    /tmp/fuzzylite/fuzzylite/./fl/norm/Norm.h:50:23: note: overridden virtual function is here
            virtual Norm* clone() const = 0;
                          ^