### PR TITLE
add Android support & remove duplicate line in FL_SOURCES

### DIFF
--- a/examples/test_android/test_android.bat
+++ b/examples/test_android/test_android.bat
@@ -1,0 +1,20 @@
+@echo off
+
+set ADB=adb.exe
+set ARCH=armeabi-v7a
+set DEVICE=/data/local/tmp
+
+echo ndk-build testfuzzylite
+call %NDK_ROOT%/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./test_android.mk APP_ABI=%ARCH% APP_PLATFORM=android-15 APP_STL=gnustl_shared APP_PIE=true
+
+echo deploy file to device
+call %ADB% push libs\%ARCH%\libfuzzylite.so %DEVICE%
+call %ADB% push libs\%ARCH%\libgnustl_shared.so %DEVICE%
+call %ADB% push libs\%ARCH%\testfuzzylite %DEVICE%
+
+echo run test on device
+call %ADB% shell chmod 751 %DEVICE%/testfuzzylite
+call %ADB% shell LD_LIBRARY_PATH=%DEVICE% %DEVICE%/testfuzzylite
+
+echo run test done!
+pause

--- a/examples/test_android/test_android.cpp
+++ b/examples/test_android/test_android.cpp
@@ -1,0 +1,68 @@
+/*
+ Author: Juan Rada-Vilela, Ph.D.
+ Copyright (C) 2010-2014 FuzzyLite Limited
+ All rights reserved
+ 
+ This file is part of fuzzylite.
+ 
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the GNU Lesser General Public License as published by the Free
+ Software Foundation, either version 3 of the License, or (at your option)
+ any later version.
+ 
+ fuzzylite is distributed in the hope that it will be useful, but WITHOUT
+ ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
+ for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public License
+ along with fuzzylite.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ fuzzylite™ is a trademark of FuzzyLite Limited.
+ 
+ */
+
+#include "fl/Headers.h"
+
+int main(int argc, char* argv[]){
+    using namespace fl;
+    Engine* engine = new Engine("simple-dimmer-android");
+
+    InputVariable* ambient = new InputVariable;
+    ambient->setName("Ambient");
+    ambient->setRange(0.000, 1.000);
+    ambient->addTerm(new Triangle("DARK", 0.000, 0.500));
+    ambient->addTerm(new Triangle("MEDIUM", 0.250, 0.750));
+    ambient->addTerm(new Triangle("BRIGHT", 0.500, 1.000));
+    engine->addInputVariable(ambient);
+
+    OutputVariable* power = new OutputVariable;
+    power->setName("Power");
+    power->setRange(0.000, 2.000);
+    power->setDefaultValue(fl::nan);
+    power->addTerm(new Triangle("LOW", 0.000, 1.000));
+    power->addTerm(new Triangle("MEDIUM", 0.500, 1.500));
+    power->addTerm(new Triangle("HIGH", 1.000, 2.000));
+    engine->addOutputVariable(power);
+
+    RuleBlock* ruleblock = new RuleBlock;
+    ruleblock->addRule(Rule::parse("if Ambient is DARK then Power is HIGH", engine));
+    ruleblock->addRule(Rule::parse("if Ambient is MEDIUM then Power is MEDIUM", engine));
+    ruleblock->addRule(Rule::parse("if Ambient is BRIGHT then Power is LOW", engine));
+    engine->addRuleBlock(ruleblock);
+
+    engine->configure("", "", "Minimum", "Maximum", "Centroid");
+
+    std::string status;
+    if (not engine->isReady(&status))
+        throw Exception("Engine not ready. "
+            "The following errors were encountered:\n" + status, FL_AT);
+
+    for (int i = 0; i < 50; ++i){
+        scalar light = ambient->getMinimum() + i * (ambient->range() / 50);
+        ambient->setValue(light);
+        engine->process();
+        FL_LOG("Ambient.input = " << Op::str(light) << " -> " <<
+            "Power.output = " << Op::str(power->getValue()));
+    }
+}

--- a/examples/test_android/test_android.mk
+++ b/examples/test_android/test_android.mk
@@ -1,0 +1,15 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := fuzzylite
+LOCAL_SRC_FILES := $(LOCAL_PATH)/../../fuzzylite/libs/$(TARGET_ARCH_ABI)/libfuzzylite.so
+LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/../../fuzzylite/
+include $(PREBUILT_SHARED_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := testfuzzylite
+LOCAL_SRC_FILES := test_android.cpp
+LOCAL_SHARED_LIBRARIES := fuzzylite
+LOCAL_CPP_FEATURES := rtti exceptions
+
+include $(BUILD_EXECUTABLE)

--- a/examples/test_android/test_android.sh
+++ b/examples/test_android/test_android.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+ADB=adb
+ARCH=armeabi-v7a
+DEVICE=/data/local/tmp
+
+echo ndk-build testfuzzylite
+$(NDK_ROOT)/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./test_android.mk APP_ABI=$(ARCH) APP_PLATFORM=android-15 APP_STL=gnustl_shared APP_PIE=true
+
+echo deploy file to device
+$(ADB) push libs/$(ARCH)/libfuzzylite.so $(DEVICE)
+$(ADB) push libs/$(ARCH)/libgnustl_shared.so $(DEVICE)
+$(ADB) push libs/$(ARCH)/testfuzzylite $(DEVICE)
+
+echo run test on device
+$(ADB) shell chmod 751 $(DEVICE)/testfuzzylite
+$(ADB) shell LD_LIBRARY_PATH=$(DEVICE) $(DEVICE)/testfuzzylite
+
+echo run test done!

--- a/fuzzylite/Android.bat
+++ b/fuzzylite/Android.bat
@@ -1,0 +1,3 @@
+@echo off
+call %NDK_ROOT%/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_ABI=armeabi-v7a APP_PLATFORM=android-15 APP_STL=gnustl_shared
+pause

--- a/fuzzylite/Android.mk
+++ b/fuzzylite/Android.mk
@@ -1,0 +1,29 @@
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := fuzzylite
+
+ifeq ($(HOST_OS), windows)
+cat := type
+else
+cat := cat
+endif
+
+fl_sources := $(shell $(cat) FL_SOURCES)
+
+LOCAL_SRC_FILES := $(fl_sources)
+
+LOCAL_CPPFLAGS += -DFL_VERSION=\"6.0\" -DFL_DATE=\"2015\" -DFL_BACKTRACE_OFF -pedantic -Wall -Wextra -DFL_EXPORT_LIBRARY
+
+# Notice: execinfo.h and backtrace() only work for glibc, unsupported by Android bionic
+# TODO: support backtrace by http://stackoverflow.com/questions/8115192/android-ndk-getting-the-backtrace
+# Add -DFL_USE_FLOAT if you need using "typedef float fl::scalar" instead of "typedef double fl::scalar"
+# Add -std=c++11 -DFL_CPP11 if you need C++11 features
+# TODO: Add -Wno-non-literal-null-conversion when using Clang Compiler
+# Enable FL_IMPORT_LIBRARY when using for BUILD_EXECUTABLE
+# Enable FL_EXPORT_LIBRARY when using for BUILD_SHARED_LIBRARY
+# Disable FL_IMPORT_LIBRARY and FL_EXPORT_LIBRARY when using for BUILD_STATIC_LIBRARY
+
+LOCAL_CPP_FEATURES := rtti exceptions
+
+include $(BUILD_SHARED_LIBRARY)

--- a/fuzzylite/Android.sh
+++ b/fuzzylite/Android.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+$(NDK_ROOT)/ndk-build NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=./Android.mk APP_ABI=armeabi-v7a APP_PLATFORM=android-15 APP_STL=gnustl_shared

--- a/fuzzylite/FL_SOURCES
+++ b/fuzzylite/FL_SOURCES
@@ -1,7 +1,6 @@
 src/Console.cpp
 src/activation/General.cpp
 src/activation/First.cpp
-src/activation/General.cpp
 src/activation/Highest.cpp
 src/activation/Last.cpp
 src/activation/Lowest.cpp


### PR DESCRIPTION
Add Android NDK standard makefile and buildscript.
Add Android test case.
Build Android shared library success.
Test success by Nexus5, AndroidL 5.1.
Remove duplicate line in FL_SOURCES (Line 2 vs Line 4).