### PR TITLE
FIS Exporter: export AlgebraicSum as probor

### DIFF
--- a/fuzzylite/src/imex/FisExporter.cpp
+++ b/fuzzylite/src/imex/FisExporter.cpp
@@ -274,7 +274,7 @@ namespace fl {
         if (norm->className() == NilpotentMinimum().className()) return "nilpotent_minimum";
         //SNorm
         if (norm->className() == Maximum().className()) return "max";
-        if (norm->className() == AlgebraicSum().className()) return "sum";
+        if (norm->className() == AlgebraicSum().className()) return "probor";
         if (norm->className() == BoundedSum().className()) return "bounded_sum";
         if (norm->className() == NormalizedSum().className()) return "normalized_sum";
         if (norm->className() == DrasticSum().className()) return "drastic_sum";


### PR DESCRIPTION
Hi,

Currently, the FIS Exporter exports the `AlgebraicSum` operator as `sum`.
This is wrong since the MATLAB's counterpart of the `AlgebraicSum` is the `probor` operator (see https://www.mathworks.com/help/fuzzy/probor.html).

Also, note that despite MATLAB allows to use the `sum` operator as a rule aggregation method, it is treated differently from `probor` (see https://www.mathworks.com/help/fuzzy/fuzzy-inference-process.html#a1054218661b1).

Best,

Marco