### PR TITLE
Add override to Extremely.h

### DIFF
--- a/fuzzylite/fl/hedge/Extremely.h
+++ b/fuzzylite/fl/hedge/Extremely.h
@@ -31,9 +31,9 @@ namespace fl {
 
     class FL_API Extremely : public Hedge {
     public:
-        std::string name() const;
-        scalar hedge(scalar x) const;
-        Extremely* clone() const;
+        std::string name() const FL_IOVERRIDE;
+        scalar hedge(scalar x) const FL_IOVERRIDE;
+        Extremely* clone() const FL_IOVERRIDE;
 
         static Hedge* constructor();
     };


### PR DESCRIPTION
These are virtual methods which are overridden. I encountered this in https://github.com/vcmi/vcmi/pull/122#discussion-diff-41819538