### PR TITLE
Handle EOF in interactive mode

### DIFF
--- a/fuzzylite/src/Console.cpp
+++ b/fuzzylite/src/Console.cpp
@@ -342,6 +342,10 @@ namespace fl {
 
             ch = readCharacter();
 
+            if (ch == EOF) {
+                break;
+            }
+
             if (std::isspace(ch)) {
                 scalar value = engine->getInputVariable(inputValues.size())->getValue();
                 try {
@@ -415,7 +419,7 @@ namespace fl {
                     inputValue.str("");
                     break;
             }
-        } while (not (ch == 'Q' or ch == 'q'));
+        } while (not (ch == 'Q' or ch == 'q' or ch == 4));
         writer << std::endl;
     }
 


### PR DESCRIPTION
This patch enables the user to press ^D to close interactive mode (as
you would expect from interactive programs). This also enables pipeing
to the application, such as:

echo '0.2 0.5' | ./release/bin/fuzzylite \
-i ../examples/mamdani/SimpleDimmer.fcl -of fld

Moreover, I never figured out how to run the tests (I think I managed to do it, but then they didn't compile), are there any documentation about running tests that I missed?