### PR TITLE
Fail build.sh on cmake/make failure

### DIFF
--- a/fuzzylite/build.sh
+++ b/fuzzylite/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 debug(){
+    set -e
     mkdir -p debug
     cd debug
     cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Debug -DFL_BACKTRACE=ON -DFL_USE_FLOAT=OFF -DFL_CPP11=OFF
@@ -9,6 +10,7 @@ debug(){
 }
 
 release(){
+    set -e
     mkdir -p release
     cd release
     cmake .. -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DFL_BACKTRACE=ON -DFL_USE_FLOAT=OFF -DFL_CPP11=OFF


### PR DESCRIPTION
Let errors in the debug and release functions cause the entire script to fail

This fixes issues such as this:

```
******************************
STARTING: release
./build.sh: line 14: cmake: command not found
make[1]: Entering directory 'fuzzylite/fuzzylite/fuzzylite/release'
make[1]: *** No targets specified and no makefile found.  Stop.
make[1]: Leaving directory 'fuzzylite/fuzzylite/fuzzylite/release'

FINISHED: release
******************************
```

Which was considered a success
