### PR TITLE
Avoid undefined behaviour due to default arg promotion

### DIFF
--- a/fuzzylite/fl/Operation.h
+++ b/fuzzylite/fl/Operation.h
@@ -1036,7 +1036,7 @@ namespace fl {
 
     template <> FL_API
     inline std::string Operation::join(int items, const std::string& separator,
-            float first, ...) {
+            double first, ...) {
         std::ostringstream ss;
         ss << str(first);
         if (items > 1) ss << separator;


### PR DESCRIPTION
Fixes compilation with clang 4