### PR TITLE
Travis: add Clang 3.9 and 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,34 @@ matrix:
   include:
     # - osx:
 
+##clang-4.0
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-4.0 FL_CPP98=OFF FL_USE_FLOAT=OFF
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-4.0 FL_CPP98=OFF FL_USE_FLOAT=ON
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-4.0 FL_CPP98=ON FL_USE_FLOAT=OFF
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-4.0 FL_CPP98=ON FL_USE_FLOAT=ON
+
+##clang-3.9
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-3.9 FL_CPP98=OFF FL_USE_FLOAT=OFF
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-3.9 FL_CPP98=OFF FL_USE_FLOAT=ON
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-3.9 FL_CPP98=ON FL_USE_FLOAT=OFF
+    - os: linux
+      compiler: clang
+      env: CXX_COMPILER=clang++-3.9 FL_CPP98=ON FL_USE_FLOAT=ON
+
 #g++-6
     - os: linux
       compiler: g++


### PR DESCRIPTION
Related to #74. It's essential to testing builds with newer clang and as far as I see from repositories 3.9 and 4.0 must be present in Xenial.