### PR TITLE
Provide full path to examples

### DIFF
--- a/fuzzylite/test/BenchmarkTest.cpp
+++ b/fuzzylite/test/BenchmarkTest.cpp
@@ -30,7 +30,7 @@ namespace fl {
     }
 
     TEST_CASE("Benchmarks from FLD files", "[benchmark][fld]") {
-        std::string path = "../../examples/";
+        std::string path = FL_BUILD_PATH "/../examples/";
         typedef std::pair<std::string, int > Example;
         std::vector<Example> examples;
         examples.push_back(Example("mamdani/AllTerms", int(1e4)));


### PR DESCRIPTION
This makes tests runnable from any path.