### PR TITLE
fuzzylite/src/main.cpp: support building with gcc-12

### DIFF
--- a/fuzzylite/src/main.cpp
+++ b/fuzzylite/src/main.cpp
@@ -21,7 +21,9 @@
 
 int main(int argc, const char* argv[]) {
     std::set_terminate(fl::Exception::terminate);
+#if __cplusplus < 201703L
     std::set_unexpected(fl::Exception::terminate);
+#endif
     ::signal(SIGSEGV, fl::Exception::signalHandler);
     ::signal(SIGABRT, fl::Exception::signalHandler);
     ::signal(SIGILL, fl::Exception::signalHandler);


### PR DESCRIPTION
 * std::set_unexpected() is removed in c++17
 * We build with -Wall -Wextra -Werror and with gcc-12, using
   std::set_unexpected will trigger the warning due to
   -Werror=deprecated-declarations which in turn is treated as an error and
   makes the build fail.