### PR TITLE
./examples/application/clean.sh: add shebang

### DIFF
--- a/examples/application/clean.sh
+++ b/examples/application/clean.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 rm -rf CMakeCache.txt CMakeFiles Makefile cmake_install.cmake FuzzyLiteDemo


### PR DESCRIPTION
The file is marked executable but has no shebang.

Alternatively: remove the executable bit if it is not meant to be run by itself.