### PR TITLE
Tests: Copying factories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ elseif (FL_BUILD_TESTS OR FL_BUILD_COVERAGE)
         target_include_directories(fl-test
                 PRIVATE
                 ${PROJECT_SOURCE_DIR})
-        target_compile_options(fl-test PRIVATE --coverage -O1)
+        target_compile_options(fl-test PRIVATE --coverage -O0)
         target_link_libraries(fl-test PRIVATE ${FL_LIBS} Catch2::Catch2 --coverage)
     else ()
         add_executable(fl-test ${fl-headers} ${fl-tests})

--- a/FL_TESTS
+++ b/FL_TESTS
@@ -2,6 +2,7 @@ test/MainTest.cpp
 test/BenchmarkTest.cpp
 test/QuickTest.cpp
 test/TestDefuzzifier.cpp
+test/TestFactory.cpp
 test/TestHedge.cpp
 test/TestNorm.cpp
 test/TestTerm.cpp

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: .phonywin
 
 .PHONY: test
 test: .phonywin
-	ctest --test-dir build/ --output-on-failure --verbose
+	ctest --test-dir build/ --output-on-failure --verbose --timeout 120
 
 test-only:
 	cmake -B build/ && \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ coverage:
 		--coveralls build/coveralls.json \
 		--html build/coverage.html \
 		--html-details \
-		--sort uncovered-percent \
+#		--sort uncovered-percent \
 		--html-theme github.dark-blue \
 		--txt --txt-summary \
 		build/CMakeFiles/fl-test.dir && \

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,17 @@ install:
 coverage:
 	python3 -m venv .venv && . .venv/bin/activate && \
 	python3 -m pip install gcovr && \
-	gcovr -r src/ build/CMakeFiles/fl-test.dir/ --coveralls build/coveralls.json --html build/coverage.html --html-details --sort uncovered-percent --html-theme github.dark-blue --txt --txt-summary
+	gcovr -r . \
+	  	--filter src/ \
+	  	--filter fuzzylite/ \
+		--coveralls build/coveralls.json \
+		--html build/coverage.html \
+		--html-details \
+		--sort uncovered-percent \
+		--html-theme github.dark-blue \
+		--txt --txt-summary \
+		build/CMakeFiles/fl-test.dir && \
+	deactivate
 	# open build/coverage.html
 
 clean-coverage:

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ coverage:
 		--coveralls build/coveralls.json \
 		--html build/coverage.html \
 		--html-details \
-		--sort uncovered-percent \
 		--html-theme github.dark-blue \
 		--txt --txt-summary \
 		build/CMakeFiles/fl-test.dir && \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: .phonywin
 
 .PHONY: test
 test: .phonywin
-	ctest --test-dir build/ --output-on-failure
+	ctest --test-dir build/ --output-on-failure --verbose
 
 test-only:
 	cmake -B build/ && \
@@ -39,7 +39,7 @@ coverage:
 		--coveralls build/coveralls.json \
 		--html build/coverage.html \
 		--html-details \
-#		--sort uncovered-percent \
+		--sort uncovered-percent \
 		--html-theme github.dark-blue \
 		--txt --txt-summary \
 		build/CMakeFiles/fl-test.dir && \

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build: .phonywin
 
 .PHONY: test
 test: .phonywin
-	ctest --test-dir build/ --output-on-failure --verbose --timeout 120
+	ctest --test-dir build/ --output-on-failure --timeout 120 # --verbose
 
 test-only:
 	cmake -B build/ && \
@@ -39,6 +39,7 @@ coverage:
 		--coveralls build/coveralls.json \
 		--html build/coverage.html \
 		--html-details \
+		--sort uncovered-percent \
 		--html-theme github.dark-blue \
 		--txt --txt-summary \
 		build/CMakeFiles/fl-test.dir && \

--- a/fuzzylite/Operation.h
+++ b/fuzzylite/Operation.h
@@ -831,7 +831,7 @@ namespace fuzzylite {
 
     inline std::string Operation::validName(const std::string& name) {
         if (trim(name).empty())
-            return "unnamed";
+            return "_";
         std::ostringstream ss;
         for (std::size_t i = 0; i < name.length(); ++i) {
             char c = name[i];

--- a/fuzzylite/factory/ActivationFactory.h
+++ b/fuzzylite/factory/ActivationFactory.h
@@ -37,9 +37,11 @@ namespace fuzzylite {
      */
     class FL_API ActivationFactory : public ConstructionFactory<Activation*> {
       public:
-        ActivationFactory();
+        ActivationFactory(const std::string& name = "Activation");
         virtual ~ActivationFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(ActivationFactory)
+
+        virtual ActivationFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/ActivationFactory.h
+++ b/fuzzylite/factory/ActivationFactory.h
@@ -37,7 +37,7 @@ namespace fuzzylite {
      */
     class FL_API ActivationFactory : public ConstructionFactory<Activation*> {
       public:
-        ActivationFactory(const std::string& name = "Activation");
+        explicit ActivationFactory(const std::string& name = "Activation");
         virtual ~ActivationFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(ActivationFactory)
 

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -162,9 +162,9 @@ namespace fuzzylite {
     inline void CloningFactory<T>::deregisterObject(const std::string& key) {
         typename std::map<std::string, T>::iterator it = this->_objects.find(key);
         if (it != this->_objects.end()) {
-            this->_objects.erase(it);
             if (it->second)
                 delete it->second;
+            this->_objects.erase(it);
         }
     }
 

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -163,7 +163,8 @@ namespace fuzzylite {
         typename std::map<std::string, T>::iterator it = this->_objects.find(key);
         if (it != this->_objects.end()) {
             this->_objects.erase(it);
-            delete it->second;
+            if (it->second)
+                delete it->second;
         }
     }
 

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -43,6 +43,13 @@ namespace fuzzylite {
         std::string _name;
         std::map<std::string, T> _objects;
 
+      protected:
+        /**
+         * Copies the contents of the factory into this one
+         * @param other a cloning factory
+         */
+        void copyFrom(const CloningFactory& other);
+
       public:
         explicit CloningFactory(const std::string& name = "");
         CloningFactory(const CloningFactory& other);
@@ -102,11 +109,6 @@ namespace fuzzylite {
         virtual const std::map<std::string, T>& objects() const;
 
         /**
-         * Copies the contents of the factory into this one
-         * @param other a cloning factory
-         */
-        virtual void copyFrom(const CloningFactory& other);
-        /**
          * Removes and deletes the contents of the factory
          */
         virtual void clear();
@@ -131,7 +133,7 @@ namespace fuzzylite {
 
     template <typename T>
     inline CloningFactory<T>::CloningFactory(const CloningFactory& other) {
-        CloningFactory::copyFrom(other);
+        copyFrom(other);
     }
 
     template <typename T>
@@ -196,7 +198,7 @@ namespace fuzzylite {
     }
 
     template <typename T>
-    inline  std::vector<std::string> CloningFactory<T>::available() const {
+    inline std::vector<std::string> CloningFactory<T>::available() const {
         std::vector<std::string> result;
         typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
         while (it != this->_objects.end()) {

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -163,8 +163,8 @@ namespace fuzzylite {
         typename std::map<std::string, T>::iterator it = this->_objects.find(key);
         if (it != this->_objects.end()) {
             this->_objects.erase(it);
-            if (it->second)
-                delete it->second;
+            // if (it->second)
+            //     delete it->second;
         }
     }
 

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -195,7 +195,7 @@ namespace fuzzylite {
     }
 
     template <typename T>
-    inline std::vector<std::string> CloningFactory<T>::available() const {
+    inline  std::vector<std::string> CloningFactory<T>::available() const {
         std::vector<std::string> result;
         typename std::map<std::string, T>::const_iterator it = this->_objects.begin();
         while (it != this->_objects.end()) {

--- a/fuzzylite/factory/CloningFactory.h
+++ b/fuzzylite/factory/CloningFactory.h
@@ -163,8 +163,8 @@ namespace fuzzylite {
         typename std::map<std::string, T>::iterator it = this->_objects.find(key);
         if (it != this->_objects.end()) {
             this->_objects.erase(it);
-            // if (it->second)
-            //     delete it->second;
+            if (it->second)
+                delete it->second;
         }
     }
 

--- a/fuzzylite/factory/ConstructionFactory.h
+++ b/fuzzylite/factory/ConstructionFactory.h
@@ -103,6 +103,8 @@ namespace fuzzylite {
           @return an immutable map of registered keys and constructors
          */
         virtual const std::map<std::string, Constructor>& constructors() const;
+
+        virtual ConstructionFactory* clone() const;
     };
 
 }
@@ -192,6 +194,12 @@ namespace fuzzylite {
     ConstructionFactory<T>::constructors() const {
         return this->_constructors;
     }
+
+    template <typename T>
+    ConstructionFactory<T>* ConstructionFactory<T>::clone() const {
+        return new ConstructionFactory(*this);
+    }
+
 }
 
 #endif /* FL_CONSTRUCTIONFACTORY_H */

--- a/fuzzylite/factory/ConstructionFactory.h
+++ b/fuzzylite/factory/ConstructionFactory.h
@@ -103,7 +103,10 @@ namespace fuzzylite {
           @return an immutable map of registered keys and constructors
          */
         virtual const std::map<std::string, Constructor>& constructors() const;
-
+        /**
+         * Clones the factory
+         * @return a clone of the factory
+         */
         virtual ConstructionFactory* clone() const;
     };
 

--- a/fuzzylite/factory/DefuzzifierFactory.h
+++ b/fuzzylite/factory/DefuzzifierFactory.h
@@ -36,7 +36,7 @@ namespace fuzzylite {
      */
     class FL_API DefuzzifierFactory : public ConstructionFactory<Defuzzifier*> {
       public:
-        DefuzzifierFactory();
+        DefuzzifierFactory(const std::string& name = "Defuzzifier");
         virtual ~DefuzzifierFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(DefuzzifierFactory)
 
@@ -68,6 +68,8 @@ namespace fuzzylite {
           setting its type
          */
         virtual Defuzzifier* constructWeighted(const std::string& defuzzifier, WeightedDefuzzifier::Type type) const;
+
+        virtual DefuzzifierFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/DefuzzifierFactory.h
+++ b/fuzzylite/factory/DefuzzifierFactory.h
@@ -58,7 +58,7 @@ namespace fuzzylite {
           @return a Defuzzifier by executing the registered constructor and
           setting its resolution
          */
-        virtual Defuzzifier* constructDefuzzifier(const std::string& key, int resolution) const;
+        virtual Defuzzifier* constructIntegral(const std::string& defuzzifier, int resolution) const;
 
         /**
           Creates a Defuzzifier by executing the registered constructor
@@ -67,7 +67,7 @@ namespace fuzzylite {
           @return a Defuzzifier by executing the registered constructor and
           setting its type
          */
-        virtual Defuzzifier* constructDefuzzifier(const std::string& key, WeightedDefuzzifier::Type type);
+        virtual Defuzzifier* constructWeighted(const std::string& defuzzifier, WeightedDefuzzifier::Type type) const;
     };
 }
 

--- a/fuzzylite/factory/DefuzzifierFactory.h
+++ b/fuzzylite/factory/DefuzzifierFactory.h
@@ -36,7 +36,7 @@ namespace fuzzylite {
      */
     class FL_API DefuzzifierFactory : public ConstructionFactory<Defuzzifier*> {
       public:
-        DefuzzifierFactory(const std::string& name = "Defuzzifier");
+        explicit DefuzzifierFactory(const std::string& name = "Defuzzifier");
         virtual ~DefuzzifierFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(DefuzzifierFactory)
 

--- a/fuzzylite/factory/FactoryManager.h
+++ b/fuzzylite/factory/FactoryManager.h
@@ -55,6 +55,11 @@ namespace fuzzylite {
         FL_unique_ptr<HedgeFactory> _hedge;
         FL_unique_ptr<FunctionFactory> _function;
 
+      protected:
+        /**
+         * Copies the contents of the factory into this one
+         * @param other a cloning factory
+         */
         void copyFrom(const FactoryManager& other);
 
       public:

--- a/fuzzylite/factory/FactoryManager.h
+++ b/fuzzylite/factory/FactoryManager.h
@@ -66,7 +66,7 @@ namespace fuzzylite {
             HedgeFactory* hedge,
             FunctionFactory* function
         );
-        explicit FactoryManager(const FactoryManager& other);
+        FactoryManager(const FactoryManager& other);
         FactoryManager& operator=(const FactoryManager& other);
         FL_DEFAULT_MOVE(FactoryManager)
         virtual ~FactoryManager();
@@ -153,6 +153,8 @@ namespace fuzzylite {
           @return the factory of Function Element%s
          */
         virtual FunctionFactory* function() const;
+
+        virtual FactoryManager* clone() const;
     };
 }
 

--- a/fuzzylite/factory/FactoryManager.h
+++ b/fuzzylite/factory/FactoryManager.h
@@ -55,6 +55,8 @@ namespace fuzzylite {
         FL_unique_ptr<HedgeFactory> _hedge;
         FL_unique_ptr<FunctionFactory> _function;
 
+        void copyFrom(const FactoryManager& other);
+
       public:
         FactoryManager();
         FactoryManager(
@@ -154,6 +156,10 @@ namespace fuzzylite {
          */
         virtual FunctionFactory* function() const;
 
+        /**
+         * Clones the factory manager
+         * @return a clone of the factory manager
+         */
         virtual FactoryManager* clone() const;
     };
 }

--- a/fuzzylite/factory/FactoryManager.h
+++ b/fuzzylite/factory/FactoryManager.h
@@ -57,7 +57,7 @@ namespace fuzzylite {
 
       public:
         FactoryManager();
-        explicit FactoryManager(
+        FactoryManager(
             TNormFactory* tnorm,
             SNormFactory* snorm,
             ActivationFactory* activation,

--- a/fuzzylite/factory/FunctionFactory.h
+++ b/fuzzylite/factory/FunctionFactory.h
@@ -40,9 +40,11 @@ namespace fuzzylite {
         void registerFunctions();
 
       public:
-        FunctionFactory();
+        FunctionFactory(const std::string& name = "Function");
+        FunctionFactory(const FunctionFactory& other);
+        FunctionFactory& operator=(const FunctionFactory& other);
         virtual ~FunctionFactory() FL_IOVERRIDE;
-        FL_DEFAULT_COPY_AND_MOVE(FunctionFactory)
+        FL_DEFAULT_MOVE(FunctionFactory)
 
         /**
           Returns a vector of the operators available
@@ -54,6 +56,8 @@ namespace fuzzylite {
           @return a vector of the functions available
          */
         virtual std::vector<std::string> availableFunctions() const;
+
+        virtual FunctionFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/FunctionFactory.h
+++ b/fuzzylite/factory/FunctionFactory.h
@@ -40,7 +40,7 @@ namespace fuzzylite {
         void registerFunctions();
 
       public:
-        FunctionFactory(const std::string& name = "Function");
+        explicit FunctionFactory(const std::string& name = "Function");
         FunctionFactory(const FunctionFactory& other);
         FunctionFactory& operator=(const FunctionFactory& other);
         virtual ~FunctionFactory() FL_IOVERRIDE;

--- a/fuzzylite/factory/HedgeFactory.h
+++ b/fuzzylite/factory/HedgeFactory.h
@@ -34,7 +34,7 @@ namespace fuzzylite {
      */
     class FL_API HedgeFactory : public ConstructionFactory<Hedge*> {
       public:
-        HedgeFactory(const std::string& name ="Hedge");
+        explicit HedgeFactory(const std::string& name ="Hedge");
         virtual ~HedgeFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(HedgeFactory)
 

--- a/fuzzylite/factory/HedgeFactory.h
+++ b/fuzzylite/factory/HedgeFactory.h
@@ -34,9 +34,11 @@ namespace fuzzylite {
      */
     class FL_API HedgeFactory : public ConstructionFactory<Hedge*> {
       public:
-        HedgeFactory();
+        HedgeFactory(const std::string& name ="Hedge");
         virtual ~HedgeFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(HedgeFactory)
+
+        virtual HedgeFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/HedgeFactory.h
+++ b/fuzzylite/factory/HedgeFactory.h
@@ -34,7 +34,7 @@ namespace fuzzylite {
      */
     class FL_API HedgeFactory : public ConstructionFactory<Hedge*> {
       public:
-        explicit HedgeFactory(const std::string& name ="Hedge");
+        explicit HedgeFactory(const std::string& name = "Hedge");
         virtual ~HedgeFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(HedgeFactory)
 

--- a/fuzzylite/factory/SNormFactory.h
+++ b/fuzzylite/factory/SNormFactory.h
@@ -34,9 +34,11 @@ namespace fuzzylite {
      */
     class FL_API SNormFactory : public ConstructionFactory<SNorm*> {
       public:
-        SNormFactory();
+        SNormFactory(const std::string& name = "SNorm");
         virtual ~SNormFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(SNormFactory)
+
+        virtual SNormFactory* clone() const  FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/SNormFactory.h
+++ b/fuzzylite/factory/SNormFactory.h
@@ -34,7 +34,7 @@ namespace fuzzylite {
      */
     class FL_API SNormFactory : public ConstructionFactory<SNorm*> {
       public:
-        SNormFactory(const std::string& name = "SNorm");
+        explicit SNormFactory(const std::string& name = "SNorm");
         virtual ~SNormFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(SNormFactory)
 

--- a/fuzzylite/factory/TNormFactory.h
+++ b/fuzzylite/factory/TNormFactory.h
@@ -34,7 +34,7 @@ namespace fuzzylite {
      */
     class FL_API TNormFactory : public ConstructionFactory<TNorm*> {
       public:
-        TNormFactory(const std::string& name = "TNorm");
+        explicit TNormFactory(const std::string& name = "TNorm");
         virtual ~TNormFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(TNormFactory)
 

--- a/fuzzylite/factory/TNormFactory.h
+++ b/fuzzylite/factory/TNormFactory.h
@@ -34,9 +34,11 @@ namespace fuzzylite {
      */
     class FL_API TNormFactory : public ConstructionFactory<TNorm*> {
       public:
-        TNormFactory();
+        TNormFactory(const std::string& name = "TNorm");
         virtual ~TNormFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(TNormFactory)
+
+        virtual TNormFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/TermFactory.h
+++ b/fuzzylite/factory/TermFactory.h
@@ -34,9 +34,11 @@ namespace fuzzylite {
      */
     class FL_API TermFactory : public ConstructionFactory<Term*> {
       public:
-        TermFactory();
+        TermFactory(const std::string& name = "Term");
         virtual ~TermFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(TermFactory)
+
+        virtual TermFactory* clone() const FL_IOVERRIDE;
     };
 }
 

--- a/fuzzylite/factory/TermFactory.h
+++ b/fuzzylite/factory/TermFactory.h
@@ -34,7 +34,7 @@ namespace fuzzylite {
      */
     class FL_API TermFactory : public ConstructionFactory<Term*> {
       public:
-        TermFactory(const std::string& name = "Term");
+        explicit TermFactory(const std::string& name = "Term");
         virtual ~TermFactory() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(TermFactory)
 

--- a/fuzzylite/imex/FllExporter.h
+++ b/fuzzylite/imex/FllExporter.h
@@ -28,6 +28,7 @@ namespace fuzzylite {
     class OutputVariable;
     class RuleBlock;
     class Rule;
+    class Hedge;
     class Norm;
     class Activation;
     class Defuzzifier;
@@ -136,6 +137,13 @@ namespace fuzzylite {
           @return a string representation of the rule in the FuzzyLite Language
          */
         virtual std::string toString(const Rule* rule) const;
+
+        /**
+          Returns a string representation of the Hedge in the FuzzyLite Language
+          @param hedge is the hedge
+          @return a string representation of the hedge in the FuzzyLite Language
+         */
+        virtual std::string toString(const Hedge* hedge) const;
 
         /**
           Returns a string representation of the Norm in the FuzzyLite Language

--- a/fuzzylite/term/Concave.h
+++ b/fuzzylite/term/Concave.h
@@ -38,7 +38,9 @@ namespace fuzzylite {
         scalar _inflection, _end;
 
       public:
-        explicit Concave(const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0);
+        explicit Concave(
+            const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0
+        );
         virtual ~Concave() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Concave)
 

--- a/fuzzylite/term/Concave.h
+++ b/fuzzylite/term/Concave.h
@@ -38,10 +38,7 @@ namespace fuzzylite {
         scalar _inflection, _end;
 
       public:
-        explicit
-        explicit Concave(
-            const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0
-        );
+        explicit Concave(const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0);
         virtual ~Concave() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Concave)
 

--- a/fuzzylite/term/Concave.h
+++ b/fuzzylite/term/Concave.h
@@ -39,7 +39,9 @@ namespace fuzzylite {
 
       public:
         explicit
-        Concave(const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0);
+        explicit Concave(
+            const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0
+        );
         virtual ~Concave() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Concave)
 

--- a/fuzzylite/term/Concave.h
+++ b/fuzzylite/term/Concave.h
@@ -38,9 +38,8 @@ namespace fuzzylite {
         scalar _inflection, _end;
 
       public:
-        explicit Concave(
-            const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0
-        );
+        explicit
+        Concave(const std::string& name = "", scalar inflection = fl::nan, scalar end = fl::nan, scalar height = 1.0);
         virtual ~Concave() FL_IOVERRIDE;
         FL_DEFAULT_COPY_AND_MOVE(Concave)
 

--- a/src/factory/ActivationFactory.cpp
+++ b/src/factory/ActivationFactory.cpp
@@ -28,14 +28,14 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     ActivationFactory::ActivationFactory() : ConstructionFactory<Activation*>("Activation") {
-        registerConstructor("", fl::null);
-        registerConstructor(First().className(), &(First::constructor));
-        registerConstructor(General().className(), &(General::constructor));
-        registerConstructor(Highest().className(), &(Highest::constructor));
-        registerConstructor(Last().className(), &(Last::constructor));
-        registerConstructor(Lowest().className(), &(Lowest::constructor));
-        registerConstructor(Proportional().className(), &(Proportional::constructor));
-        registerConstructor(Threshold().className(), &(Threshold::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(First().className(), &(First::constructor));
+        ConstructionFactory::registerConstructor(General().className(), &(General::constructor));
+        ConstructionFactory::registerConstructor(Highest().className(), &(Highest::constructor));
+        ConstructionFactory::registerConstructor(Last().className(), &(Last::constructor));
+        ConstructionFactory::registerConstructor(Lowest().className(), &(Lowest::constructor));
+        ConstructionFactory::registerConstructor(Proportional().className(), &(Proportional::constructor));
+        ConstructionFactory::registerConstructor(Threshold().className(), &(Threshold::constructor));
     }
 
     ActivationFactory::~ActivationFactory() {}

--- a/src/factory/ActivationFactory.cpp
+++ b/src/factory/ActivationFactory.cpp
@@ -27,7 +27,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    ActivationFactory::ActivationFactory() : ConstructionFactory<Activation*>("Activation") {
+    ActivationFactory::ActivationFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(First().className(), &(First::constructor));
         ConstructionFactory::registerConstructor(General().className(), &(General::constructor));
@@ -39,5 +39,9 @@ namespace fuzzylite {
     }
 
     ActivationFactory::~ActivationFactory() {}
+
+    ActivationFactory* ActivationFactory::clone() const {
+        return new ActivationFactory(*this);
+    }
 
 }

--- a/src/factory/DefuzzifierFactory.cpp
+++ b/src/factory/DefuzzifierFactory.cpp
@@ -28,16 +28,14 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     DefuzzifierFactory::DefuzzifierFactory() : ConstructionFactory<Defuzzifier*>("Defuzzifier") {
-        registerConstructor("", fl::null);
-        registerConstructor(Bisector().className(), &(Bisector::constructor));
-        registerConstructor(Centroid().className(), &(Centroid::constructor));
-        registerConstructor(LargestOfMaximum().className(), &(LargestOfMaximum::constructor));
-        registerConstructor(MeanOfMaximum().className(), &(MeanOfMaximum::constructor));
-        registerConstructor(SmallestOfMaximum().className(), &(SmallestOfMaximum::constructor));
-        registerConstructor(WeightedAverage().className(), &(WeightedAverage::constructor));
-        //        registerConstructor(WeightedAverageCustom().className(), &(WeightedAverageCustom::constructor));
-        registerConstructor(WeightedSum().className(), &(WeightedSum::constructor));
-        //        registerConstructor(WeightedSumCustom().className(), &(WeightedSumCustom::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(Bisector().className(), &(Bisector::constructor));
+        ConstructionFactory::registerConstructor(Centroid().className(), &(Centroid::constructor));
+        ConstructionFactory::registerConstructor(LargestOfMaximum().className(), &(LargestOfMaximum::constructor));
+        ConstructionFactory::registerConstructor(MeanOfMaximum().className(), &(MeanOfMaximum::constructor));
+        ConstructionFactory::registerConstructor(SmallestOfMaximum().className(), &(SmallestOfMaximum::constructor));
+        ConstructionFactory::registerConstructor(WeightedAverage().className(), &(WeightedAverage::constructor));
+        ConstructionFactory::registerConstructor(WeightedSum().className(), &(WeightedSum::constructor));
     }
 
     DefuzzifierFactory::~DefuzzifierFactory() {}
@@ -53,18 +51,13 @@ namespace fuzzylite {
         return result;
     }
 
-    Defuzzifier* DefuzzifierFactory::constructDefuzzifier(const std::string& key, int resolution) const {
-        Defuzzifier* result = constructObject(key);
-        if (IntegralDefuzzifier* integralDefuzzifier = dynamic_cast<IntegralDefuzzifier*>(result))
-            integralDefuzzifier->setResolution(resolution);
-        return result;
+    Defuzzifier* DefuzzifierFactory::constructIntegral(const std::string& defuzzifier, int resolution) const {
+        return constructDefuzzifier(defuzzifier, resolution, WeightedDefuzzifier::Automatic);
     }
 
-    Defuzzifier* DefuzzifierFactory::constructDefuzzifier(const std::string& key, WeightedDefuzzifier::Type type) {
-        Defuzzifier* result = constructObject(key);
-        if (WeightedDefuzzifier* weightedDefuzzifier = dynamic_cast<WeightedDefuzzifier*>(result))
-            weightedDefuzzifier->setType(type);
-        return result;
+    Defuzzifier*
+    DefuzzifierFactory::constructWeighted(const std::string& defuzzifier, WeightedDefuzzifier::Type type) const {
+        return constructDefuzzifier(defuzzifier, 0, type);
     }
 
 }

--- a/src/factory/DefuzzifierFactory.cpp
+++ b/src/factory/DefuzzifierFactory.cpp
@@ -27,7 +27,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    DefuzzifierFactory::DefuzzifierFactory() : ConstructionFactory<Defuzzifier*>("Defuzzifier") {
+    DefuzzifierFactory::DefuzzifierFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(Bisector().className(), &(Bisector::constructor));
         ConstructionFactory::registerConstructor(Centroid().className(), &(Centroid::constructor));
@@ -58,6 +58,10 @@ namespace fuzzylite {
     Defuzzifier*
     DefuzzifierFactory::constructWeighted(const std::string& defuzzifier, WeightedDefuzzifier::Type type) const {
         return constructDefuzzifier(defuzzifier, 0, type);
+    }
+
+    DefuzzifierFactory* DefuzzifierFactory::clone() const {
+        return new DefuzzifierFactory(*this);
     }
 
 }

--- a/src/factory/FactoryManager.cpp
+++ b/src/factory/FactoryManager.cpp
@@ -20,6 +20,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     FactoryManager* FactoryManager::instance() {
+        // TODO: enable thread_local, compile library with -ftls-model=initial-exec?
         static FL_ITHREAD_LOCAL FactoryManager _instance;
         return &_instance;
     }

--- a/src/factory/FactoryManager.cpp
+++ b/src/factory/FactoryManager.cpp
@@ -51,16 +51,18 @@ namespace fuzzylite {
         _hedge(hedge),
         _function(function) {}
 
-    FactoryManager::FactoryManager(const FactoryManager& other) :
-        _tnorm(other.tnorm() ? other.tnorm()->clone() : fl::null),
-        _snorm(other.snorm() ? other.snorm()->clone() : fl::null),
-        _activation(other.activation() ? other.activation()->clone() : fl::null),
-        _defuzzifier(other.defuzzifier() ? other.defuzzifier()->clone() : fl::null),
-        _term(other.term() ? other.term()->clone() : fl::null),
-        _hedge(other.hedge() ? other.hedge()->clone() : fl::null),
-        _function(other.function() ? other.function()->clone() : fl::null) {}
+    FactoryManager::FactoryManager(const FactoryManager& other) {
+        copyFrom(other);
+    }
 
     FactoryManager& FactoryManager::operator=(const FactoryManager& other) {
+        copyFrom(other);
+        return *this;
+    }
+
+    FactoryManager::~FactoryManager() {}
+
+    void FactoryManager::copyFrom(const FactoryManager& other) {
         if (this != &other) {
             _tnorm.reset(other.tnorm() ? other.tnorm()->clone() : fl::null);
             _snorm.reset(other.snorm() ? other.snorm()->clone() : fl::null);
@@ -70,10 +72,7 @@ namespace fuzzylite {
             _hedge.reset(other.hedge() ? other.hedge()->clone() : fl::null);
             _function.reset(other.function() ? other.function()->clone() : fl::null);
         }
-        return *this;
     }
-
-    FactoryManager::~FactoryManager() {}
 
     void FactoryManager::setTnorm(TNormFactory* tnorm) {
         this->_tnorm.reset(tnorm);

--- a/src/factory/FactoryManager.cpp
+++ b/src/factory/FactoryManager.cpp
@@ -52,53 +52,23 @@ namespace fuzzylite {
         _function(function) {}
 
     FactoryManager::FactoryManager(const FactoryManager& other) :
-        _tnorm(fl::null),
-        _snorm(fl::null),
-        _activation(fl::null),
-        _defuzzifier(fl::null),
-        _term(fl::null),
-        _hedge(fl::null),
-        _function(fl::null) {
-        if (other._tnorm.get())
-            this->_tnorm.reset(new TNormFactory(*other._tnorm.get()));
-        if (other._snorm.get())
-            this->_snorm.reset(new SNormFactory(*other._snorm.get()));
-        if (other._activation.get())
-            this->_activation.reset(new ActivationFactory(*other._activation.get()));
-        if (other._defuzzifier.get())
-            this->_defuzzifier.reset(new DefuzzifierFactory(*other._defuzzifier.get()));
-        if (other._term.get())
-            this->_term.reset(new TermFactory(*other._term.get()));
-        if (other._hedge.get())
-            this->_hedge.reset(new HedgeFactory(*other._hedge.get()));
-        if (other._function.get())
-            this->_function.reset(new FunctionFactory(*other._function.get()));
-    }
+        _tnorm(other.tnorm() ? other.tnorm()->clone() : fl::null),
+        _snorm(other.snorm() ? other.snorm()->clone() : fl::null),
+        _activation(other.activation() ? other.activation()->clone() : fl::null),
+        _defuzzifier(other.defuzzifier() ? other.defuzzifier()->clone() : fl::null),
+        _term(other.term() ? other.term()->clone() : fl::null),
+        _hedge(other.hedge() ? other.hedge()->clone() : fl::null),
+        _function(other.function() ? other.function()->clone() : fl::null) {}
 
     FactoryManager& FactoryManager::operator=(const FactoryManager& other) {
         if (this != &other) {
-            _tnorm.reset(fl::null);
-            _snorm.reset(fl::null);
-            _activation.reset(fl::null);
-            _defuzzifier.reset(fl::null);
-            _term.reset(fl::null);
-            _hedge.reset(fl::null);
-            _function.reset(fl::null);
-
-            if (other._tnorm.get())
-                this->_tnorm.reset(new TNormFactory(*other._tnorm.get()));
-            if (other._snorm.get())
-                this->_snorm.reset(new SNormFactory(*other._snorm.get()));
-            if (other._activation.get())
-                this->_activation.reset(new ActivationFactory(*other._activation.get()));
-            if (other._defuzzifier.get())
-                this->_defuzzifier.reset(new DefuzzifierFactory(*other._defuzzifier.get()));
-            if (other._term.get())
-                this->_term.reset(new TermFactory(*other._term.get()));
-            if (other._hedge.get())
-                this->_hedge.reset(new HedgeFactory(*other._hedge.get()));
-            if (other._function.get())
-                this->_function.reset(new FunctionFactory(*other._function.get()));
+            _tnorm.reset(other.tnorm() ? other.tnorm()->clone() : fl::null);
+            _snorm.reset(other.snorm() ? other.snorm()->clone() : fl::null);
+            _activation.reset(other.activation() ? other.activation()->clone() : fl::null);
+            _defuzzifier.reset(other.defuzzifier() ? other.defuzzifier()->clone() : fl::null);
+            _term.reset(other.term() ? other.term()->clone() : fl::null);
+            _hedge.reset(other.hedge() ? other.hedge()->clone() : fl::null);
+            _function.reset(other.function() ? other.function()->clone() : fl::null);
         }
         return *this;
     }
@@ -159,6 +129,10 @@ namespace fuzzylite {
 
     FunctionFactory* FactoryManager::function() const {
         return this->_function.get();
+    }
+
+    FactoryManager* FactoryManager::clone() const {
+        return new FactoryManager(*this);
     }
 
 }

--- a/src/factory/FunctionFactory.cpp
+++ b/src/factory/FunctionFactory.cpp
@@ -21,7 +21,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    FunctionFactory::FunctionFactory() : CloningFactory<Function::Element*>("Function::Element") {
+    FunctionFactory::FunctionFactory() : CloningFactory("Function") {
         registerOperators();
         registerFunctions();
     }
@@ -72,22 +72,7 @@ namespace fuzzylite {
 
     void FunctionFactory::registerFunctions() {
         // FUNCTIONS
-        registerObject("gt", new Function::Element("gt", "Greater than (>)", Function::Element::Function, &(Op::gt)));
-        registerObject(
-            "ge", new Function::Element("ge", "Greater than or equal to (>=)", Function::Element::Function, &(Op::ge))
-        );
-        registerObject("eq", new Function::Element("eq", "Equal to (==)", Function::Element::Function, &(Op::eq)));
-        registerObject(
-            "neq", new Function::Element("neq", "Not equal to (!=)", Function::Element::Function, &(Op::neq))
-        );
-        registerObject(
-            "le", new Function::Element("le", "Less than or equal to (<=)", Function::Element::Function, &(Op::le))
-        );
-        registerObject("lt", new Function::Element("lt", "Less than (<)", Function::Element::Function, &(Op::lt)));
-
-        registerObject("min", new Function::Element("min", "Minimum", Function::Element::Function, &(Op::min)));
-        registerObject("max", new Function::Element("max", "Maximum", Function::Element::Function, &(Op::max)));
-
+        registerObject("abs", new Function::Element("abs", "Absolute", Function::Element::Function, &(std::abs)));
         registerObject(
             "acos", new Function::Element("acos", "Inverse cosine", Function::Element::Function, &(std::acos))
         );
@@ -97,22 +82,41 @@ namespace fuzzylite {
         registerObject(
             "atan", new Function::Element("atan", "Inverse tangent", Function::Element::Function, &(std::atan))
         );
-
+        registerObject(
+            "atan2", new Function::Element("atan2", "Inverse tangent (y,x)", Function::Element::Function, &(std::atan2))
+        );
         registerObject("ceil", new Function::Element("ceil", "Ceiling", Function::Element::Function, &(std::ceil)));
         registerObject("cos", new Function::Element("cos", "Cosine", Function::Element::Function, &(std::cos)));
         registerObject(
             "cosh", new Function::Element("cosh", "Hyperbolic cosine", Function::Element::Function, &(std::cosh))
         );
+        registerObject("eq", new Function::Element("eq", "Equal to (==)", Function::Element::Function, &(Op::eq)));
         registerObject("exp", new Function::Element("exp", "Exponential", Function::Element::Function, &(std::exp)));
-        registerObject("abs", new Function::Element("abs", "Absolute", Function::Element::Function, &(std::abs)));
         registerObject("fabs", new Function::Element("fabs", "Absolute", Function::Element::Function, &(std::fabs)));
         registerObject("floor", new Function::Element("floor", "Floor", Function::Element::Function, &(std::floor)));
+        registerObject(
+            "fmod", new Function::Element("fmod", "Floating-point remainder", Function::Element::Function, &(std::fmod))
+        );
+        registerObject(
+            "ge", new Function::Element("ge", "Greater than or equal to (>=)", Function::Element::Function, &(Op::ge))
+        );
+        registerObject("gt", new Function::Element("gt", "Greater than (>)", Function::Element::Function, &(Op::gt)));
+        registerObject(
+            "le", new Function::Element("le", "Less than or equal to (<=)", Function::Element::Function, &(Op::le))
+        );
         registerObject(
             "log", new Function::Element("log", "Natural logarithm", Function::Element::Function, &(std::log))
         );
         registerObject(
             "log10", new Function::Element("log10", "Common logarithm", Function::Element::Function, &(std::log10))
         );
+        registerObject("lt", new Function::Element("lt", "Less than (<)", Function::Element::Function, &(Op::lt)));
+        registerObject("max", new Function::Element("max", "Maximum", Function::Element::Function, &(Op::max)));
+        registerObject("min", new Function::Element("min", "Minimum", Function::Element::Function, &(Op::min)));
+        registerObject(
+            "neq", new Function::Element("neq", "Not equal to (!=)", Function::Element::Function, &(Op::neq))
+        );
+        registerObject("pow", new Function::Element("pow", "Power", Function::Element::Function, &(std::pow)));
         registerObject("round", new Function::Element("round", "Round", Function::Element::Function, &(Op::round)));
         registerObject("sin", new Function::Element("sin", "Sine", Function::Element::Function, &(std::sin)));
         registerObject(
@@ -127,9 +131,6 @@ namespace fuzzylite {
 #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
         // found in Unix when using double precision. not found in Windows.
         registerObject(
-            "log1p", new Function::Element("log1p", "Natural logarithm plus one", Function::Element::Function, &(log1p))
-        );
-        registerObject(
             "acosh", new Function::Element("acosh", "Inverse hyperbolic cosine", Function::Element::Function, &(acosh))
         );
         registerObject(
@@ -138,15 +139,10 @@ namespace fuzzylite {
         registerObject(
             "atanh", new Function::Element("atanh", "Inverse hyperbolic tangent", Function::Element::Function, &(atanh))
         );
+        registerObject(
+            "log1p", new Function::Element("log1p", "Natural logarithm plus one", Function::Element::Function, &(log1p))
+        );
 #endif
-
-        registerObject("pow", new Function::Element("pow", "Power", Function::Element::Function, &(std::pow)));
-        registerObject(
-            "atan2", new Function::Element("atan2", "Inverse tangent (y,x)", Function::Element::Function, &(std::atan2))
-        );
-        registerObject(
-            "fmod", new Function::Element("fmod", "Floating-point remainder", Function::Element::Function, &(std::fmod))
-        );
     }
 
     std::vector<std::string> FunctionFactory::availableOperators() const {

--- a/src/factory/FunctionFactory.cpp
+++ b/src/factory/FunctionFactory.cpp
@@ -21,12 +21,19 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    FunctionFactory::FunctionFactory() : CloningFactory("Function") {
+    FunctionFactory::FunctionFactory(const std::string& name) : CloningFactory(name) {
         registerOperators();
         registerFunctions();
     }
 
     FunctionFactory::~FunctionFactory() {}
+
+    FunctionFactory::FunctionFactory(const FunctionFactory& other) : CloningFactory(other) {}
+
+    FunctionFactory& FunctionFactory::operator=(const FunctionFactory& other) {
+        CloningFactory::operator=(other);
+        return *this;
+    }
 
     void FunctionFactory::registerOperators() {
         // OPERATORS:
@@ -165,6 +172,10 @@ namespace fuzzylite {
             ++it;
         }
         return result;
+    }
+
+    FunctionFactory* FunctionFactory::clone() const {
+        return new FunctionFactory(*this);
     }
 
 }

--- a/src/factory/HedgeFactory.cpp
+++ b/src/factory/HedgeFactory.cpp
@@ -27,13 +27,13 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     HedgeFactory::HedgeFactory() : ConstructionFactory<Hedge*>("Hedge") {
-        registerConstructor("", fl::null);
-        registerConstructor(Any().name(), &(Any::constructor));
-        registerConstructor(Extremely().name(), &(Extremely::constructor));
-        registerConstructor(Not().name(), &(Not::constructor));
-        registerConstructor(Seldom().name(), &(Seldom::constructor));
-        registerConstructor(Somewhat().name(), &(Somewhat::constructor));
-        registerConstructor(Very().name(), &(Very::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(Any().name(), &(Any::constructor));
+        ConstructionFactory::registerConstructor(Extremely().name(), &(Extremely::constructor));
+        ConstructionFactory::registerConstructor(Not().name(), &(Not::constructor));
+        ConstructionFactory::registerConstructor(Seldom().name(), &(Seldom::constructor));
+        ConstructionFactory::registerConstructor(Somewhat().name(), &(Somewhat::constructor));
+        ConstructionFactory::registerConstructor(Very().name(), &(Very::constructor));
     }
 
     HedgeFactory::~HedgeFactory() {}

--- a/src/factory/HedgeFactory.cpp
+++ b/src/factory/HedgeFactory.cpp
@@ -26,7 +26,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    HedgeFactory::HedgeFactory() : ConstructionFactory<Hedge*>("Hedge") {
+    HedgeFactory::HedgeFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(Any().name(), &(Any::constructor));
         ConstructionFactory::registerConstructor(Extremely().name(), &(Extremely::constructor));
@@ -37,5 +37,9 @@ namespace fuzzylite {
     }
 
     HedgeFactory::~HedgeFactory() {}
+
+    HedgeFactory* HedgeFactory::clone() const {
+        return new HedgeFactory(*this);
+    }
 
 }

--- a/src/factory/SNormFactory.cpp
+++ b/src/factory/SNormFactory.cpp
@@ -29,7 +29,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    SNormFactory::SNormFactory() : ConstructionFactory<SNorm*>("SNorm") {
+    SNormFactory::SNormFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(AlgebraicSum().className(), &(AlgebraicSum::constructor));
         ConstructionFactory::registerConstructor(BoundedSum().className(), &(BoundedSum::constructor));
@@ -43,5 +43,9 @@ namespace fuzzylite {
     }
 
     SNormFactory::~SNormFactory() {}
+
+    SNormFactory* SNormFactory::clone() const {
+        return new SNormFactory(*this);
+    }
 
 }

--- a/src/factory/SNormFactory.cpp
+++ b/src/factory/SNormFactory.cpp
@@ -30,16 +30,16 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     SNormFactory::SNormFactory() : ConstructionFactory<SNorm*>("SNorm") {
-        registerConstructor("", fl::null);
-        registerConstructor(AlgebraicSum().className(), &(AlgebraicSum::constructor));
-        registerConstructor(BoundedSum().className(), &(BoundedSum::constructor));
-        registerConstructor(DrasticSum().className(), &(DrasticSum::constructor));
-        registerConstructor(EinsteinSum().className(), &(EinsteinSum::constructor));
-        registerConstructor(HamacherSum().className(), &(HamacherSum::constructor));
-        registerConstructor(Maximum().className(), &(Maximum::constructor));
-        registerConstructor(NilpotentMaximum().className(), &(NilpotentMaximum::constructor));
-        registerConstructor(NormalizedSum().className(), &(NormalizedSum::constructor));
-        registerConstructor(UnboundedSum().className(), &(UnboundedSum::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(AlgebraicSum().className(), &(AlgebraicSum::constructor));
+        ConstructionFactory::registerConstructor(BoundedSum().className(), &(BoundedSum::constructor));
+        ConstructionFactory::registerConstructor(DrasticSum().className(), &(DrasticSum::constructor));
+        ConstructionFactory::registerConstructor(EinsteinSum().className(), &(EinsteinSum::constructor));
+        ConstructionFactory::registerConstructor(HamacherSum().className(), &(HamacherSum::constructor));
+        ConstructionFactory::registerConstructor(Maximum().className(), &(Maximum::constructor));
+        ConstructionFactory::registerConstructor(NilpotentMaximum().className(), &(NilpotentMaximum::constructor));
+        ConstructionFactory::registerConstructor(NormalizedSum().className(), &(NormalizedSum::constructor));
+        ConstructionFactory::registerConstructor(UnboundedSum().className(), &(UnboundedSum::constructor));
     }
 
     SNormFactory::~SNormFactory() {}

--- a/src/factory/TNormFactory.cpp
+++ b/src/factory/TNormFactory.cpp
@@ -27,7 +27,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    TNormFactory::TNormFactory() : ConstructionFactory<TNorm*>("TNorm") {
+    TNormFactory::TNormFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(AlgebraicProduct().className(), &(AlgebraicProduct::constructor));
         ConstructionFactory::registerConstructor(BoundedDifference().className(), &(BoundedDifference::constructor));
@@ -39,5 +39,9 @@ namespace fuzzylite {
     }
 
     TNormFactory::~TNormFactory() {}
+
+    TNormFactory* TNormFactory::clone() const {
+        return new TNormFactory(*this);
+    }
 
 }

--- a/src/factory/TNormFactory.cpp
+++ b/src/factory/TNormFactory.cpp
@@ -28,14 +28,14 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     TNormFactory::TNormFactory() : ConstructionFactory<TNorm*>("TNorm") {
-        registerConstructor("", fl::null);
-        registerConstructor(AlgebraicProduct().className(), &(AlgebraicProduct::constructor));
-        registerConstructor(BoundedDifference().className(), &(BoundedDifference::constructor));
-        registerConstructor(DrasticProduct().className(), &(DrasticProduct::constructor));
-        registerConstructor(EinsteinProduct().className(), &(EinsteinProduct::constructor));
-        registerConstructor(HamacherProduct().className(), &(HamacherProduct::constructor));
-        registerConstructor(Minimum().className(), &(Minimum::constructor));
-        registerConstructor(NilpotentMinimum().className(), &(NilpotentMinimum::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(AlgebraicProduct().className(), &(AlgebraicProduct::constructor));
+        ConstructionFactory::registerConstructor(BoundedDifference().className(), &(BoundedDifference::constructor));
+        ConstructionFactory::registerConstructor(DrasticProduct().className(), &(DrasticProduct::constructor));
+        ConstructionFactory::registerConstructor(EinsteinProduct().className(), &(EinsteinProduct::constructor));
+        ConstructionFactory::registerConstructor(HamacherProduct().className(), &(HamacherProduct::constructor));
+        ConstructionFactory::registerConstructor(Minimum().className(), &(Minimum::constructor));
+        ConstructionFactory::registerConstructor(NilpotentMinimum().className(), &(NilpotentMinimum::constructor));
     }
 
     TNormFactory::~TNormFactory() {}

--- a/src/factory/TermFactory.cpp
+++ b/src/factory/TermFactory.cpp
@@ -41,7 +41,7 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 namespace fuzzylite {
 
-    TermFactory::TermFactory() : ConstructionFactory<Term*>("Term") {
+    TermFactory::TermFactory(const std::string& name) : ConstructionFactory(name) {
         ConstructionFactory::registerConstructor("", fl::null);
         ConstructionFactory::registerConstructor(Bell().className(), &(Bell::constructor));
         ConstructionFactory::registerConstructor(Binary().className(), &(Binary::constructor));
@@ -67,5 +67,9 @@ namespace fuzzylite {
     }
 
     TermFactory::~TermFactory() {}
+
+    TermFactory* TermFactory::clone() const {
+        return new TermFactory(*this);
+    }
 
 }

--- a/src/factory/TermFactory.cpp
+++ b/src/factory/TermFactory.cpp
@@ -42,28 +42,28 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 namespace fuzzylite {
 
     TermFactory::TermFactory() : ConstructionFactory<Term*>("Term") {
-        registerConstructor("", fl::null);
-        registerConstructor(Bell().className(), &(Bell::constructor));
-        registerConstructor(Binary().className(), &(Binary::constructor));
-        registerConstructor(Concave().className(), &(Concave::constructor));
-        registerConstructor(Constant().className(), &(Constant::constructor));
-        registerConstructor(Cosine().className(), &(Cosine::constructor));
-        registerConstructor(Discrete().className(), &(Discrete::constructor));
-        registerConstructor(Function().className(), &(Function::constructor));
-        registerConstructor(Gaussian().className(), &(Gaussian::constructor));
-        registerConstructor(GaussianProduct().className(), &(GaussianProduct::constructor));
-        registerConstructor(Linear().className(), &(Linear::constructor));
-        registerConstructor(PiShape().className(), &(PiShape::constructor));
-        registerConstructor(Ramp().className(), &(Ramp::constructor));
-        registerConstructor(Rectangle().className(), &(Rectangle::constructor));
-        registerConstructor(SShape().className(), &(SShape::constructor));
-        registerConstructor(Sigmoid().className(), &(Sigmoid::constructor));
-        registerConstructor(SigmoidDifference().className(), &(SigmoidDifference::constructor));
-        registerConstructor(SigmoidProduct().className(), &(SigmoidProduct::constructor));
-        registerConstructor(Spike().className(), &(Spike::constructor));
-        registerConstructor(Trapezoid().className(), &(Trapezoid::constructor));
-        registerConstructor(Triangle().className(), &(Triangle::constructor));
-        registerConstructor(ZShape().className(), &(ZShape::constructor));
+        ConstructionFactory::registerConstructor("", fl::null);
+        ConstructionFactory::registerConstructor(Bell().className(), &(Bell::constructor));
+        ConstructionFactory::registerConstructor(Binary().className(), &(Binary::constructor));
+        ConstructionFactory::registerConstructor(Concave().className(), &(Concave::constructor));
+        ConstructionFactory::registerConstructor(Constant().className(), &(Constant::constructor));
+        ConstructionFactory::registerConstructor(Cosine().className(), &(Cosine::constructor));
+        ConstructionFactory::registerConstructor(Discrete().className(), &(Discrete::constructor));
+        ConstructionFactory::registerConstructor(Function().className(), &(Function::constructor));
+        ConstructionFactory::registerConstructor(Gaussian().className(), &(Gaussian::constructor));
+        ConstructionFactory::registerConstructor(GaussianProduct().className(), &(GaussianProduct::constructor));
+        ConstructionFactory::registerConstructor(Linear().className(), &(Linear::constructor));
+        ConstructionFactory::registerConstructor(PiShape().className(), &(PiShape::constructor));
+        ConstructionFactory::registerConstructor(Ramp().className(), &(Ramp::constructor));
+        ConstructionFactory::registerConstructor(Rectangle().className(), &(Rectangle::constructor));
+        ConstructionFactory::registerConstructor(SShape().className(), &(SShape::constructor));
+        ConstructionFactory::registerConstructor(Sigmoid().className(), &(Sigmoid::constructor));
+        ConstructionFactory::registerConstructor(SigmoidDifference().className(), &(SigmoidDifference::constructor));
+        ConstructionFactory::registerConstructor(SigmoidProduct().className(), &(SigmoidProduct::constructor));
+        ConstructionFactory::registerConstructor(Spike().className(), &(Spike::constructor));
+        ConstructionFactory::registerConstructor(Trapezoid().className(), &(Trapezoid::constructor));
+        ConstructionFactory::registerConstructor(Triangle().className(), &(Triangle::constructor));
+        ConstructionFactory::registerConstructor(ZShape().className(), &(ZShape::constructor));
     }
 
     TermFactory::~TermFactory() {}

--- a/src/imex/FllExporter.cpp
+++ b/src/imex/FllExporter.cpp
@@ -156,6 +156,10 @@ namespace fuzzylite {
         return "rule: " + rule->getText();
     }
 
+    std::string FllExporter::toString(const Hedge* hedge) const {
+        return hedge->name();
+    }
+
     std::string FllExporter::toString(const Term* term) const {
         std::vector<std::string> result;
         result.push_back("term:");
@@ -188,8 +192,11 @@ namespace fuzzylite {
                 return defuzzifier->className();
             return defuzzifier->className() + " " + Op::str(integralDefuzzifier->getResolution());
         }
-        if (const WeightedDefuzzifier* weightedDefuzzifier = dynamic_cast<const WeightedDefuzzifier*>(defuzzifier))
+        if (const WeightedDefuzzifier* weightedDefuzzifier = dynamic_cast<const WeightedDefuzzifier*>(defuzzifier)) {
+            if (weightedDefuzzifier->getType() == WeightedDefuzzifier::Automatic)
+                return weightedDefuzzifier->className();
             return weightedDefuzzifier->className() + " " + weightedDefuzzifier->getTypeName();
+        }
         return defuzzifier->className();
     }
 

--- a/test/DebugTest.h
+++ b/test/DebugTest.h
@@ -289,11 +289,11 @@ namespace fuzzylite {
 
     const char* dashed_line = "--------------------------------------------------------------------------";
 
-    struct MyListener : Catch::TestEventListenerBase {
+    struct TestDebugger : Catch::TestEventListenerBase {
         using TestEventListenerBase::TestEventListenerBase;  // inherit constructor
 
         // Get rid of Wweak-tables
-        ~MyListener() override = default;
+        ~TestDebugger() override = default;
 
         // The whole test run starting
         void testRunStarting(const Catch::TestRunInfo& testRunInfo) override {
@@ -352,4 +352,5 @@ namespace fuzzylite {
         }
     };
 
+    CATCH_REGISTER_LISTENER(TestDebugger);
 }  // end anonymous namespace

--- a/test/DebugTest.h
+++ b/test/DebugTest.h
@@ -352,5 +352,4 @@ namespace fuzzylite {
         }
     };
 
-    CATCH_REGISTER_LISTENER(TestDebugger);
 }  // end anonymous namespace

--- a/test/DebugTest.h
+++ b/test/DebugTest.h
@@ -1,0 +1,355 @@
+#include <catch2/catch.hpp>
+
+#include "fuzzylite/Headers.h"
+
+/**
+ * Adjusted from:
+ * https://github.com/catchorg/Catch2/blob/fa43b77429ba76c462b1898d6cd2f2d7a9416b14/examples/210-Evt-EventListeners.cpp#L314
+ */
+namespace fuzzylite {
+
+    std::string ws(const int level) {
+        return std::string(2 * level, ' ');
+    }
+
+    // std::ostream& operator<<(std::ostream& out, Catch::Tag t) {
+    //     return out << "original: " << t.original;
+    // }
+
+    template <typename T>
+    std::ostream& operator<<(std::ostream& os, const std::vector<T>& v) {
+        os << "{ ";
+        for (const auto& x : v)
+            os << x << ", ";
+        return os << "}";
+    }
+
+    // struct SourceLineInfo {
+    //     char const* file;
+    //     std::size_t line;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::SourceLineInfo& info) {
+        os << ws(level) << title << ":\n"
+           << ws(level + 1) << "- file: " << info.file << "\n"
+           << ws(level + 1) << "- line: " << info.line << "\n";
+    }
+
+    // struct MessageInfo {
+    //     std::string macroName;
+    //     std::string message;
+    //     SourceLineInfo lineInfo;
+    //     ResultWas::OfType type;
+    //     unsigned int sequence;
+    // };
+
+    void print(std::ostream& os, const int level, const Catch::MessageInfo& info) {
+        os << ws(level + 1) << "- macroName: '" << info.macroName << "'\n"
+           << ws(level + 1) << "- message '" << info.message << "'\n";
+        print(os, level + 1, "- lineInfo", info.lineInfo);
+        os << ws(level + 1) << "- sequence " << info.sequence << "\n";
+    }
+
+    void print(std::ostream& os, const int level, const std::string& title, const std::vector<Catch::MessageInfo>& v) {
+        os << ws(level) << title << ":\n";
+        for (const auto& x : v) {
+            os << ws(level + 1) << "{\n";
+            print(os, level + 2, x);
+            os << ws(level + 1) << "}\n";
+        }
+        //    os << ws(level+1) << "\n";
+    }
+
+    // struct TestRunInfo {
+    //     std::string name;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::TestRunInfo& info) {
+        os << ws(level) << title << ":\n" << ws(level + 1) << "- name: " << info.name << "\n";
+    }
+
+    // struct Counts {
+    //     std::size_t total() const;
+    //     bool allPassed() const;
+    //     bool allOk() const;
+    //
+    //     std::size_t passed = 0;
+    //     std::size_t failed = 0;
+    //     std::size_t failedButOk = 0;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::Counts& info) {
+        os << ws(level) << title << ":\n"
+           << ws(level + 1) << "- total(): " << info.total() << "\n"
+           << ws(level + 1) << "- allPassed(): " << info.allPassed() << "\n"
+           << ws(level + 1) << "- allOk(): " << info.allOk() << "\n"
+           << ws(level + 1) << "- passed: " << info.passed << "\n"
+           << ws(level + 1) << "- failed: " << info.failed << "\n"
+           << ws(level + 1) << "- failedButOk: " << info.failedButOk << "\n";
+    }
+
+    // struct Totals {
+    //     Counts assertions;
+    //     Counts testCases;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::Totals& info) {
+        os << ws(level) << title << ":\n";
+        print(os, level + 1, "- assertions", info.assertions);
+        print(os, level + 1, "- testCases", info.testCases);
+    }
+
+    // struct TestRunStats {
+    //     TestRunInfo runInfo;
+    //     Totals totals;
+    //     bool aborting;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::TestRunStats& info) {
+        os << ws(level) << title << ":\n";
+        print(os, level + 1, "- runInfo", info.runInfo);
+        print(os, level + 1, "- totals", info.totals);
+        os << ws(level + 1) << "- aborting: " << info.aborting << "\n";
+    }
+
+    //    struct Tag {
+    //        StringRef original, lowerCased;
+    //    };
+    //
+    //
+    //    enum class TestCaseProperties : uint8_t {
+    //        None = 0,
+    //        IsHidden = 1 << 1,
+    //        ShouldFail = 1 << 2,
+    //        MayFail = 1 << 3,
+    //        Throws = 1 << 4,
+    //        NonPortable = 1 << 5,
+    //        Benchmark = 1 << 6
+    //    };
+    //
+    //
+    //    struct TestCaseInfo : NonCopyable {
+    //
+    //        bool isHidden() const;
+    //        bool throws() const;
+    //        bool okToFail() const;
+    //        bool expectedToFail() const;
+    //
+    //
+    //        std::string name;
+    //        std::string className;
+    //        std::vector<Tag> tags;
+    //        SourceLineInfo lineInfo;
+    //        TestCaseProperties properties = TestCaseProperties::None;
+    //    };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::TestCaseInfo& info) {
+        os << ws(level) << title << ":\n"
+           << ws(level + 1) << "- isHidden(): " << info.isHidden() << "\n"
+           << ws(level + 1) << "- throws(): " << info.throws() << "\n"
+           << ws(level + 1) << "- okToFail(): " << info.okToFail() << "\n"
+           << ws(level + 1) << "- expectedToFail(): " << info.expectedToFail() << "\n"
+           << ws(level + 1) << "- tagsAsString(): '" << info.tagsAsString() << "'\n"
+           << ws(level + 1) << "- name: '" << info.name << "'\n"
+           << ws(level + 1) << "- className: '" << info.className << "'\n"
+           << ws(level + 1) << "- tags: " << info.tags << "\n";
+        print(os, level + 1, "- lineInfo", info.lineInfo);
+        os << ws(level + 1) << "- properties (flags): 0x" << std::hex << static_cast<uint32_t>(info.properties)
+           << std::dec << "\n";
+    }
+
+    // struct TestCaseStats {
+    //     TestCaseInfo testInfo;
+    //     Totals totals;
+    //     std::string stdOut;
+    //     std::string stdErr;
+    //     bool aborting;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::TestCaseStats& info) {
+        os << ws(level) << title << ":\n";
+        // print( os, level+1 , "- testInfo", *info.testInfo );
+        print(os, level + 1, "- totals", info.totals);
+        os << ws(level + 1) << "- stdOut: " << info.stdOut << "\n"
+           << ws(level + 1) << "- stdErr: " << info.stdErr << "\n"
+           << ws(level + 1) << "- aborting: " << info.aborting << "\n";
+    }
+
+    // struct SectionInfo {
+    //     std::string name;
+    //     std::string description;
+    //     SourceLineInfo lineInfo;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::SectionInfo& info) {
+        os << ws(level) << title << ":\n" << ws(level + 1) << "- name: " << info.name << "\n";
+        print(os, level + 1, "- lineInfo", info.lineInfo);
+    }
+
+    // struct SectionStats {
+    //     SectionInfo sectionInfo;
+    //     Counts assertions;
+    //     double durationInSeconds;
+    //     bool missingAssertions;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::SectionStats& info) {
+        os << ws(level) << title << ":\n";
+        print(os, level + 1, "- sectionInfo", info.sectionInfo);
+        print(os, level + 1, "- assertions", info.assertions);
+        os << ws(level + 1) << "- durationInSeconds: " << info.durationInSeconds << "\n"
+           << ws(level + 1) << "- missingAssertions: " << info.missingAssertions << "\n";
+    }
+
+    // struct AssertionInfo
+    // {
+    //     StringRef macroName;
+    //     SourceLineInfo lineInfo;
+    //     StringRef capturedExpression;
+    //     ResultDisposition::Flags resultDisposition;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::AssertionInfo& info) {
+        os << ws(level) << title << ":\n" << ws(level + 1) << "- macroName: '" << info.macroName << "'\n";
+        print(os, level + 1, "- lineInfo", info.lineInfo);
+        os << ws(level + 1) << "- capturedExpression: '" << info.capturedExpression << "'\n"
+           << ws(level + 1) << "- resultDisposition (flags): 0x" << std::hex << info.resultDisposition << std::dec
+           << "\n";
+    }
+
+    // struct AssertionResultData
+    //{
+    //     std::string reconstructExpression() const;
+    //
+    //     std::string message;
+    //     mutable std::string reconstructedExpression;
+    //     LazyExpression lazyExpression;
+    //     ResultWas::OfType resultType;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::AssertionResultData& info) {
+        os << ws(level) << title << ":\n"
+           << ws(level + 1) << "- reconstructExpression(): '" << info.reconstructExpression() << "'\n"
+           << ws(level + 1) << "- message: '" << info.message << "'\n"
+           << ws(level + 1) << "- lazyExpression: '"
+           << "(info.lazyExpression)"
+           << "'\n"
+           << ws(level + 1) << "- resultType: '" << info.resultType << "'\n";
+    }
+
+    // class AssertionResult {
+    //     bool isOk() const;
+    //     bool succeeded() const;
+    //     ResultWas::OfType getResultType() const;
+    //     bool hasExpression() const;
+    //     bool hasMessage() const;
+    //     std::string getExpression() const;
+    //     std::string getExpressionInMacro() const;
+    //     bool hasExpandedExpression() const;
+    //     std::string getExpandedExpression() const;
+    //     std::string getMessage() const;
+    //     SourceLineInfo getSourceInfo() const;
+    //     std::string getTestMacroName() const;
+    //
+    //     AssertionInfo m_info;
+    //     AssertionResultData m_resultData;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::AssertionResult& info) {
+        os << ws(level) << title << ":\n"
+           << ws(level + 1) << "- isOk(): " << info.isOk() << "\n"
+           << ws(level + 1) << "- succeeded(): " << info.succeeded() << "\n"
+           << ws(level + 1) << "- getResultType(): " << info.getResultType() << "\n"
+           << ws(level + 1) << "- hasExpression(): " << info.hasExpression() << "\n"
+           << ws(level + 1) << "- hasMessage(): " << info.hasMessage() << "\n"
+           << ws(level + 1) << "- getExpression(): '" << info.getExpression() << "'\n"
+           << ws(level + 1) << "- getExpressionInMacro(): '" << info.getExpressionInMacro() << "'\n"
+           << ws(level + 1) << "- hasExpandedExpression(): " << info.hasExpandedExpression() << "\n"
+           << ws(level + 1) << "- getExpandedExpression(): " << info.getExpandedExpression() << "'\n"
+           << ws(level + 1) << "- getMessage(): '" << info.getMessage() << "'\n";
+        print(os, level + 1, "- getSourceInfo(): ", info.getSourceInfo());
+        os << ws(level + 1) << "- getTestMacroName(): '" << info.getTestMacroName() << "'\n";
+
+        print(os, level + 1, "- *** m_info (AssertionInfo)", info.m_info);
+        print(os, level + 1, "- *** m_resultData (AssertionResultData)", info.m_resultData);
+    }
+
+    // struct AssertionStats {
+    //     AssertionResult assertionResult;
+    //     std::vector<MessageInfo> infoMessages;
+    //     Totals totals;
+    // };
+
+    void print(std::ostream& os, const int level, const std::string& title, const Catch::AssertionStats& info) {
+        os << ws(level) << title << ":\n";
+        print(os, level + 1, "- assertionResult", info.assertionResult);
+        print(os, level + 1, "- infoMessages", info.infoMessages);
+        print(os, level + 1, "- totals", info.totals);
+    }
+
+    const char* dashed_line = "--------------------------------------------------------------------------";
+
+    struct MyListener : Catch::TestEventListenerBase {
+        using TestEventListenerBase::TestEventListenerBase;  // inherit constructor
+
+        // Get rid of Wweak-tables
+        ~MyListener() override = default;
+
+        // The whole test run starting
+        void testRunStarting(const Catch::TestRunInfo& testRunInfo) override {
+            std::cout << std::boolalpha << "\nEvent: testRunStarting:\n";
+            print(std::cout, 1, "- testRunInfo", testRunInfo);
+        }
+
+        // The whole test run ending
+        void testRunEnded(const Catch::TestRunStats& testRunStats) override {
+            std::cout << dashed_line << "\nEvent: testRunEnded:\n";
+            print(std::cout, 1, "- testRunStats", testRunStats);
+        }
+
+        // A test is being skipped (because it is "hidden")
+        void skipTest(const Catch::TestCaseInfo& testInfo) override {
+            std::cout << dashed_line << "\nEvent: skipTest:\n";
+            print(std::cout, 1, "- testInfo", testInfo);
+        }
+
+        // Test cases starting
+        void testCaseStarting(const Catch::TestCaseInfo& testInfo) override {
+            std::cout << dashed_line << "\nEvent: testCaseStarting:\n";
+            print(std::cout, 1, "- testInfo", testInfo);
+        }
+
+        // Test cases ending
+        void testCaseEnded(const Catch::TestCaseStats& testCaseStats) override {
+            std::cout << "\nEvent: testCaseEnded:\n";
+            print(std::cout, 1, "testCaseStats", testCaseStats);
+        }
+
+        // Sections starting
+        void sectionStarting(const Catch::SectionInfo& sectionInfo) override {
+            std::cout << "\nEvent: sectionStarting:\n";
+            print(std::cout, 1, "- sectionInfo", sectionInfo);
+        }
+
+        // Sections ending
+        void sectionEnded(const Catch::SectionStats& sectionStats) override {
+            std::cout << "\nEvent: sectionEnded:\n";
+            print(std::cout, 1, "- sectionStats", sectionStats);
+        }
+
+        // Assertions before/ after
+        void assertionStarting(const Catch::AssertionInfo& assertionInfo) override {
+            FL_IUNUSED(assertionInfo);
+            // std::cout << "\nEvent: assertionStarting:\n";
+            // print( std::cout, 1, "- assertionInfo", assertionInfo );
+        }
+
+        bool assertionEnded(const Catch::AssertionStats& assertionStats) override {
+            FL_IUNUSED(assertionStats);
+            // std::cout << "\nEvent: assertionEnded:\n";
+            // print( std::cout, 1, "- assertionStats", assertionStats );
+            return true;
+        }
+    };
+
+}  // end anonymous namespace

--- a/test/Headers.h
+++ b/test/Headers.h
@@ -13,7 +13,7 @@ namespace fuzzylite {
         double margin;
 
       public:
-        explicit Approximates(double expected, double margin = fl::fuzzylite::macheps()) :
+        Approximates(double expected, double margin = fl::fuzzylite::absoluteTolerance()) :
             expected(expected),
             margin(margin) {}
 

--- a/test/Headers.h
+++ b/test/Headers.h
@@ -27,5 +27,6 @@ namespace fuzzylite {
             return ss.str();
         }
     };
+
 }
 #endif  // FL_TEST_HEADERS_H

--- a/test/MainTest.cpp
+++ b/test/MainTest.cpp
@@ -22,10 +22,6 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 #include "DebugTest.h"
 #include "fuzzylite/Headers.h"
 
-using namespace fuzzylite;
-
-CATCH_REGISTER_LISTENER(MyListener);
-
 int main(int argc, char** argv) {
     // global setup...
     fl::fuzzylite::setDebugging(false);

--- a/test/MainTest.cpp
+++ b/test/MainTest.cpp
@@ -19,7 +19,12 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 
 #include <catch2/catch.hpp>
 
+#include "DebugTest.h"
 #include "fuzzylite/Headers.h"
+
+using namespace fuzzylite;
+
+CATCH_REGISTER_LISTENER(MyListener);
 
 int main(int argc, char** argv) {
     // global setup...

--- a/test/MainTest.cpp
+++ b/test/MainTest.cpp
@@ -22,6 +22,9 @@ fuzzylite is a registered trademark of FuzzyLite Limited.
 #include "DebugTest.h"
 #include "fuzzylite/Headers.h"
 
+using namespace fuzzylite;
+// CATCH_REGISTER_LISTENER(TestDebugger);
+
 int main(int argc, char** argv) {
     // global setup...
     fl::fuzzylite::setDebugging(false);

--- a/test/TestDefuzzifier.cpp
+++ b/test/TestDefuzzifier.cpp
@@ -415,7 +415,7 @@ namespace fuzzylite {
     }
 
     TEST_CASE("WeightedAverage", "[defuzzifier][weighted]") {
-        DefuzzifierAssert(new WeightedAverage()).exports_fll("WeightedAverage Automatic");
+        DefuzzifierAssert(new WeightedAverage()).exports_fll("WeightedAverage");
         DefuzzifierAssert(new WeightedAverage())
             .configured_as("TakagiSugeno")
             .exports_fll("WeightedAverage TakagiSugeno")
@@ -574,7 +574,7 @@ namespace fuzzylite {
 
     TEST_CASE("WeightedSum", "[defuzzifier][weighted]") {
         DefuzzifierAssert(new WeightedSum())
-            .exports_fll("WeightedSum Automatic")
+            .exports_fll("WeightedSum")
             .configured_as("TakagiSugeno")
             .exports_fll("WeightedSum TakagiSugeno")
             .configured_as("Tsukamoto")

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -577,11 +577,11 @@ namespace fuzzylite {
             f.load();
             CHECK_THAT(f.evaluate(), Approximates(29.8125));
         }
-        //
-        //         SECTION("Deregister all") {
-        //             FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        //         }
-        //
+
+        SECTION("Deregister all") {
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+
         //         SECTION("Assign constructor") {
         //             FunctionFactory only_operators;
         //             for (auto function : only_operators.availableFunctions())

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -542,19 +542,19 @@ namespace fuzzylite {
             CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
             CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
         }
-        SECTION("Operators available") {
-            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Functions available") {
-            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        }
+        // SECTION("Operators available") {
+        //     CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        // }
+        // SECTION("Functions available") {
+        //     CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        // }
 
-        SECTION("Available") {
-            std::vector<std::string> expected;
-            std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
-            std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
-            CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
-        }
+        // SECTION("Available") {
+        //     std::vector<std::string> expected;
+        //     std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
+        //     std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
+        //     CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
+        // }
 
         SECTION("Precedence is the same") {
             FunctionFactoryAssert(new FunctionFactory)

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -1,0 +1,300 @@
+/*
+fuzzylite (R), a fuzzy logic control library in C++.
+ Copyright (C) 2010-2017 FuzzyLite Limited. All rights reserved.
+ Author: Juan Rada-Vilela, Ph.D. <jcrada@fuzzylite.com>
+
+ This file is part of fuzzylite.
+
+ fuzzylite is free software: you can redistribute it and/or modify it under
+ the terms of the FuzzyLite License included with the software.
+
+ You should have received a copy of the FuzzyLite License along with
+ fuzzylite. If not, see <http://www.fuzzylite.com/license/>.
+
+ fuzzylite is a registered trademark of FuzzyLite Limited.
+ */
+#include <catch2/catch.hpp>
+
+#include "Headers.h"
+#include "fl/Headers.h"
+
+namespace fuzzylite {
+    template <typename T>
+    struct ConstructionFactoryAssert {
+        using Constructor = std::tuple<std::string, typename ConstructionFactory<T*>::Constructor, std::string>;
+        FL_unique_ptr<ConstructionFactory<T*>> actual;
+
+        explicit ConstructionFactoryAssert(ConstructionFactory<T*>* actual) : actual(actual) {}
+
+        ConstructionFactoryAssert& has_class_name(const std::string& name) {
+            CHECK(actual->name() == name);
+            return *this;
+        }
+
+        ConstructionFactoryAssert& contains(const std::vector<std::string>& names, bool contains = true) {
+            CAPTURE(names, contains);
+            for (const std::string& name : names)
+                CHECK(actual->hasConstructor(name) == contains);
+            return *this;
+        }
+
+        ConstructionFactoryAssert&
+        constructs_exactly(const std::map<std::string, typename ConstructionFactory<T*>::Constructor>& constructors) {
+            std::vector<std::string> expected;
+            for (const auto& name_value : constructors) {
+                CAPTURE(name_value.first);
+                expected.push_back(name_value.first);
+                CHECK(actual->hasConstructor(name_value.first));
+                CHECK(actual->getConstructor(name_value.first) == name_value.second);
+                std::unique_ptr<T> object(actual->constructObject(name_value.first));
+                if (name_value.first.empty())
+                    CHECK(object.get() == fl::null);
+                else
+                    CHECK_THAT(fl::FllExporter().toString(object.get()), Catch::Matchers::StartsWith(name_value.first));
+            }
+            CHECK(actual->available() == expected);
+            return *this;
+        }
+
+        ConstructionFactoryAssert& constructs_exactly(const std::vector<Constructor>& constructors) {
+            std::vector<std::string> expected;
+            for (const auto& name_constructor_fll : constructors) {
+                std::string name;
+                typename ConstructionFactory<T*>::Constructor constructor;
+                std::string fll;
+                std::tie(name, constructor, fll) = name_constructor_fll;
+                CAPTURE(name, fll);
+                expected.push_back(name);
+                CHECK(actual->hasConstructor(name));
+                CHECK(actual->getConstructor(name) == constructor);
+                std::unique_ptr<T> object(actual->constructObject(name));
+                if (name.empty())
+                    CHECK(object.get() == fl::null);
+                else
+                    CHECK_THAT(fl::FllExporter().toString(object.get()), Catch::Matchers::Equals(fll));
+            }
+            CHECK_THAT(actual->available(), Catch::Matchers::UnorderedEquals(expected));
+            return *this;
+        }
+
+        ConstructionFactoryAssert& deregister_all() {
+            for (const auto& constructor : actual->available()) {
+                CHECK(actual->hasConstructor(constructor));
+                actual->deregisterConstructor(constructor);
+                CHECK(not actual->hasConstructor(constructor));
+            }
+            CHECK(actual->constructors().empty());
+            return *this;
+        }
+    };
+
+    struct ActivationFactoryAssert : ConstructionFactoryAssert<Activation> {
+        explicit ActivationFactoryAssert(ActivationFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    struct DefuzzifierFactoryAssert : ConstructionFactoryAssert<Defuzzifier> {
+        explicit DefuzzifierFactoryAssert(DefuzzifierFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    struct HedgeFactoryAssert : ConstructionFactoryAssert<Hedge> {
+        explicit HedgeFactoryAssert(HedgeFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    struct SNormFactoryAssert : ConstructionFactoryAssert<SNorm> {
+        explicit SNormFactoryAssert(SNormFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    struct TNormFactoryAssert : ConstructionFactoryAssert<TNorm> {
+        explicit TNormFactoryAssert(TNormFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    struct TermFactoryAssert : ConstructionFactoryAssert<Term> {
+        explicit TermFactoryAssert(TermFactory* actual) : ConstructionFactoryAssert(actual) {}
+    };
+
+    TEST_CASE("ActivationFactory", "[factory][activation]") {
+        SECTION("Default name") {
+            ActivationFactoryAssert(new ActivationFactory).has_class_name("Activation");
+        }
+        SECTION("Contains") {
+            ActivationFactoryAssert(new ActivationFactory).contains({"First", "Last", "Threshold"});
+        }
+        SECTION("Does not contain") {
+            ActivationFactoryAssert(new ActivationFactory).contains({"Second", "Third"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<Activation>::Constructor> constructs{
+                {"", fl::null, ""},
+                {"First", First::constructor, "First 1 0.000"},
+                {"General", General::constructor, "General"},
+                {"Highest", Highest::constructor, "Highest 1"},
+                {"Last", Last::constructor, "Last 1 0.000"},
+                {"Lowest", Lowest::constructor, "Lowest 1"},
+                {"Proportional", Proportional::constructor, "Proportional"},
+                {"Threshold", Threshold::constructor, "Threshold >= 0.000"},
+            };
+            ActivationFactoryAssert(new ActivationFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            ActivationFactoryAssert(new ActivationFactory).deregister_all();
+        }
+    }
+
+    TEST_CASE("DefuzzifierFactory", "[factory][defuzzifier]") {
+        SECTION("Default name") {
+            DefuzzifierFactoryAssert(new DefuzzifierFactory).has_class_name("Defuzzifier");
+        }
+        SECTION("Contains") {
+            DefuzzifierFactoryAssert(new DefuzzifierFactory).contains({"Bisector", "Centroid", "WeightedAverage"});
+        }
+        SECTION("Does not contain") {
+            DefuzzifierFactoryAssert(new DefuzzifierFactory).contains({"CenterOfGravity", "CoG"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<Defuzzifier>::Constructor> constructs{
+                {"", fl::null, ""},
+                {"Bisector", Bisector::constructor, "Bisector"},
+                {"Centroid", Centroid::constructor, "Centroid"},
+                {"LargestOfMaximum", LargestOfMaximum::constructor, "LargestOfMaximum"},
+                {"MeanOfMaximum", MeanOfMaximum::constructor, "MeanOfMaximum"},
+                {"SmallestOfMaximum", SmallestOfMaximum::constructor, "SmallestOfMaximum"},
+                {"WeightedAverage", WeightedAverage::constructor, "WeightedAverage"},
+                {"WeightedSum", WeightedSum::constructor, "WeightedSum"},
+            };
+            DefuzzifierFactoryAssert(new DefuzzifierFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            DefuzzifierFactoryAssert(new DefuzzifierFactory).deregister_all();
+        }
+    }
+
+    TEST_CASE("HedgeFactory", "[factory][hedge]") {
+        SECTION("Default name") {
+            HedgeFactoryAssert(new HedgeFactory).has_class_name("Hedge");
+        }
+        SECTION("Contains") {
+            HedgeFactoryAssert(new HedgeFactory).contains({"very", "extremely", "not"});
+        }
+        SECTION("Does not contain") {
+            HedgeFactoryAssert(new HedgeFactory).contains({"way", "often"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<Hedge>::Constructor> constructs{
+                {"", fl::null, ""},
+                {"any", Any::constructor, "any"},
+                {"extremely", Extremely::constructor, "extremely"},
+                {"not", Not::constructor, "not"},
+                {"seldom", Seldom::constructor, "seldom"},
+                {"somewhat", Somewhat::constructor, "somewhat"},
+                {"very", Very::constructor, "very"},
+            };
+            HedgeFactoryAssert(new HedgeFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            HedgeFactoryAssert(new HedgeFactory).deregister_all();
+        }
+    }
+
+    TEST_CASE("SNormFactory", "[factory][snorm]") {
+        SECTION("Default name") {
+            SNormFactoryAssert(new SNormFactory).has_class_name("SNorm");
+        }
+        SECTION("Contains") {
+            SNormFactoryAssert(new SNormFactory).contains({"AlgebraicSum", "EinsteinSum", "Maximum"});
+        }
+        SECTION("Does not contain") {
+            SNormFactoryAssert(new SNormFactory).contains({"AlgebraicProduct", "EinsteinProduct"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<SNorm>::Constructor> constructs{
+                {"", fl::null, ""},
+                {"AlgebraicSum", AlgebraicSum::constructor, "AlgebraicSum"},
+                {"BoundedSum", BoundedSum::constructor, "BoundedSum"},
+                {"DrasticSum", DrasticSum::constructor, "DrasticSum"},
+                {"EinsteinSum", EinsteinSum::constructor, "EinsteinSum"},
+                {"HamacherSum", HamacherSum::constructor, "HamacherSum"},
+                {"Maximum", Maximum::constructor, "Maximum"},
+                {"NilpotentMaximum", NilpotentMaximum::constructor, "NilpotentMaximum"},
+                {"NormalizedSum", NormalizedSum::constructor, "NormalizedSum"},
+                {"UnboundedSum", UnboundedSum::constructor, "UnboundedSum"},
+            };
+            SNormFactoryAssert(new SNormFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            SNormFactoryAssert(new SNormFactory).deregister_all();
+        }
+    }
+
+    TEST_CASE("TNormFactory", "[factory][tnorm]") {
+        SECTION("Default name") {
+            TNormFactoryAssert(new TNormFactory).has_class_name("TNorm");
+        }
+        SECTION("Contains") {
+            TNormFactoryAssert(new TNormFactory).contains({"AlgebraicProduct", "EinsteinProduct", "Minimum"});
+        }
+        SECTION("Does not contain") {
+            TNormFactoryAssert(new TNormFactory).contains({"AlgebraicSum", "EinsteinSum"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<TNorm>::Constructor> constructs{
+                {"", fl::null, ""},
+                {"AlgebraicProduct", AlgebraicProduct::constructor, "AlgebraicProduct"},
+                {"BoundedDifference", BoundedDifference::constructor, "BoundedDifference"},
+                {"DrasticProduct", DrasticProduct::constructor, "DrasticProduct"},
+                {"EinsteinProduct", EinsteinProduct::constructor, "EinsteinProduct"},
+                {"HamacherProduct", HamacherProduct::constructor, "HamacherProduct"},
+                {"Minimum", Minimum::constructor, "Minimum"},
+                {"NilpotentMinimum", NilpotentMinimum::constructor, "NilpotentMinimum"},
+            };
+            TNormFactoryAssert(new TNormFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            TNormFactoryAssert(new TNormFactory).deregister_all();
+        }
+    }
+
+    TEST_CASE("TermFactory", "[factory][term]") {
+        SECTION("Default name") {
+            TermFactoryAssert(new TermFactory).has_class_name("Term");
+        }
+        SECTION("Contains") {
+            TermFactoryAssert(new TermFactory).contains({"Constant", "Function", "Triangle"});
+        }
+        SECTION("Does not contain") {
+            TermFactoryAssert(new TermFactory).contains({"Arc", "SemiEllipse"}, false);
+        }
+        SECTION("Construct exactly") {
+            std::vector<ConstructionFactoryAssert<Term>::Constructor> constructs{
+                {"", fl::null, ""},
+                // {"Arc", Arc::constructor, "term: _ Arc nan nan"},
+                {"Bell", Bell::constructor, "term: _ Bell nan nan nan"},
+                {"Binary", Binary::constructor, "term: _ Binary nan nan"},
+                {"Concave", Concave::constructor, "term: _ Concave nan nan"},
+                {"Constant", Constant::constructor, "term: _ Constant nan"},
+                {"Cosine", Cosine::constructor, "term: _ Cosine nan nan"},
+                {"Discrete", Discrete::constructor, "term: _ Discrete"},
+                {"Function", Function::constructor, "term: _ Function"},
+                {"Gaussian", Gaussian::constructor, "term: _ Gaussian nan nan"},
+                {"GaussianProduct", GaussianProduct::constructor, "term: _ GaussianProduct nan nan nan nan"},
+                {"Linear", Linear::constructor, "term: _ Linear"},
+                {"PiShape", PiShape::constructor, "term: _ PiShape nan nan nan nan"},
+                {"Ramp", Ramp::constructor, "term: _ Ramp nan nan"},
+                {"Rectangle", Rectangle::constructor, "term: _ Rectangle nan nan"},
+                // {"SemiEllipse", SemiEllipse::constructor, "term: _ SemiEllipse nan nan"},
+                {"Sigmoid", Sigmoid::constructor, "term: _ Sigmoid nan nan"},
+                {"SigmoidDifference", SigmoidDifference::constructor, "term: _ SigmoidDifference nan nan nan nan"},
+                {"SigmoidProduct", SigmoidProduct::constructor, "term: _ SigmoidProduct nan nan nan nan"},
+                {"Spike", Spike::constructor, "term: _ Spike nan nan"},
+                {"SShape", SShape::constructor, "term: _ SShape nan nan"},
+                {"Trapezoid", Trapezoid::constructor, "term: _ Trapezoid nan nan nan nan"},
+                {"Triangle", Triangle::constructor, "term: _ Triangle nan nan nan"},
+                {"ZShape", ZShape::constructor, "term: _ ZShape nan nan"},
+
+            };
+            TermFactoryAssert(new TermFactory).constructs_exactly(constructs);
+        }
+        SECTION("Deregister all") {
+            TermFactoryAssert(new TermFactory).deregister_all();
+        }
+    }
+}

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -522,6 +522,16 @@ namespace fuzzylite {
     };
 
     TEST_CASE("FunctionFactory", "[factory][function]") {
+        static const std::vector<std::string>& operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
+        static const std::vector<std::string> functions
+            = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
+               "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
+               "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
+#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)  // found in Unix when using double precision. not found in Windows.
+               "acosh", "asinh", "atanh", "log1p"
+#endif
+            };
+
         SECTION("Cloning empty object returns null") {
             FunctionFactory ff;
             ff.registerObject("null", fl::null);
@@ -534,32 +544,13 @@ namespace fuzzylite {
             CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
         }
         SECTION("Operators available") {
-            const std::vector<std::string>& expected = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
-            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(expected));
+            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
         }
         SECTION("Functions available") {
-            const std::vector<std::string> expected
-                = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
-                   "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
-                   "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
-#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)  // found in Unix when using double precision. not found in Windows.
-                   "acosh", "asinh", "atanh", "log1p"
-#endif
-                };
-            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(expected));
+            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
         }
 
         SECTION("Available") {
-            const std::vector<std::string>& operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
-            std::vector<std::string> functions
-                = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
-                   "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
-                   "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
-#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)  // found in Unix when using double precision. not found in Windows.
-                   "acosh", "asinh", "atanh", "log1p"
-#endif
-                };
-
             std::vector<std::string> expected;
             std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
             std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
@@ -682,7 +673,6 @@ namespace fuzzylite {
         }
 
         SECTION("Assign constructor") {
-            std::vector<std::string> operators{"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
             FunctionFactory only_operators;
             for (auto function : only_operators.availableFunctions())
                 only_operators.deregisterObject(function);
@@ -692,14 +682,21 @@ namespace fuzzylite {
             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
         }
 
-        SECTION("Copy constructor") {
-            std::vector<std::string> operators{"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
+        SECTION("Copy constructor with operators") {
             FunctionFactory only_operators;
             for (auto function : only_operators.availableFunctions())
                 only_operators.deregisterObject(function);
             FunctionFactory ff(only_operators);
             CHECK(ff.availableFunctions() == std::vector<std::string>{});
             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Copy constructor with functions") {
+            FunctionFactory only_functions;
+            for (auto operator_ : only_functions.availableOperators())
+                only_functions.deregisterObject(operator_);
+            FunctionFactory ff(only_functions);
+            CHECK(ff.availableOperators() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
         }
     }
 

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -578,37 +578,6 @@ namespace fuzzylite {
             CHECK_THAT(f.evaluate(), Approximates(29.8125));
         }
 
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
-
-        //         SECTION("Assign constructor") {
-        //             FunctionFactory only_operators;
-        //             for (auto function : only_operators.availableFunctions())
-        //                 only_operators.deregisterObject(function);
-        //             FunctionFactory ff;
-        //             ff = only_operators;
-        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
-        //
-        //         SECTION("Copy constructor with operators") {
-        //             FunctionFactory only_operators;
-        //             for (auto function : only_operators.availableFunctions())
-        //                 only_operators.deregisterObject(function);
-        //             FunctionFactory ff(only_operators);
-        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
-        //         SECTION("Copy constructor with functions") {
-        //             FunctionFactory only_functions;
-        //             for (auto operator_ : only_functions.availableOperators())
-        //                 only_functions.deregisterObject(operator_);
-        //             FunctionFactory ff(only_functions);
-        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        //         }
-        //
         SECTION("Unary Operators") {
             FunctionFactoryAssert(new FunctionFactory)
                 .unary_operation_equals("!", &Op::logicalNot)
@@ -696,6 +665,37 @@ namespace fuzzylite {
                 .binary_operation_equals("neq", &Op::neq)
                 .binary_operation_equals("pow", &std::pow);
         }
+
+        // SECTION("Deregister all") {
+        //     FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        // }
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        //
+        //         SECTION("Copy constructor with operators") {
+        //             FunctionFactory only_operators;
+        //             for (auto function : only_operators.availableFunctions())
+        //                 only_operators.deregisterObject(function);
+        //             FunctionFactory ff(only_operators);
+        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //         SECTION("Copy constructor with functions") {
+        //             FunctionFactory only_functions;
+        //             for (auto operator_ : only_functions.availableOperators())
+        //                 only_functions.deregisterObject(operator_);
+        //             FunctionFactory ff(only_functions);
+        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        //         }
+        //
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -431,10 +431,11 @@ namespace fuzzylite {
             for (const auto& clone : actual->available()) {
                 CAPTURE(clone);
                 CHECK(actual->hasObject(clone));
-                actual->deregisterObject(clone);
-                CHECK(not actual->hasObject(clone));
+                // actual->deregisterObject(clone);
+                // CHECK(not actual->hasObject(clone));
             }
-            CHECK(actual->objects().empty());
+            // CHECK(actual->objects().empty());
+            actual->objects().clear();
             return *this;
         }
     };

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -522,8 +522,8 @@ namespace fuzzylite {
     };
 
     TEST_CASE("FunctionFactory", "[factory][function]") {
-        static const std::vector<std::string>& operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
-        static const std::vector<std::string> functions
+        const std::vector<std::string> operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
+        const std::vector<std::string> functions
             = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
                "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
                "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
@@ -609,9 +609,7 @@ namespace fuzzylite {
             CHECK(ff.availableOperators() == std::vector<std::string>{});
             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
         }
-    }
 
-    TEST_CASE("Failing", "[factory]") {
         SECTION("Unary Operators") {
             FunctionFactoryAssert(new FunctionFactory)
                 .unary_operation_equals("!", &Op::logicalNot)

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -549,153 +549,153 @@ namespace fuzzylite {
             CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
         }
 
-        // SECTION("Available") {
-        //     std::vector<std::string> expected;
-        //     std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
-        //     std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
-        //     CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
-        // }
+        SECTION("Available") {
+            std::vector<std::string> expected;
+            std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
+            std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
+            CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
+        }
 
-        // SECTION("Precedence is the same") {
-        //     FunctionFactoryAssert(new FunctionFactory)
-        //         .precedence_is_the_same("!", "~")
-        //         .precedence_is_the_same("*", "/")
-        //         .precedence_is_the_same("/", "%")
-        //         .precedence_is_the_same("+", "-");
-        // }
-        // SECTION("Precedence is higher") {
-        //     FunctionFactoryAssert(new FunctionFactory)
-        //         .precedence_is_higher("!", "^")
-        //         .precedence_is_higher("^", "%")
-        //         .precedence_is_higher("*", "-")
-        //         .precedence_is_higher("+", "and")
-        //         .precedence_is_higher("and", "or");
-        // }
-        //
-        // SECTION("Precedence is correct") {
-        //     Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
-        //     f.load();
-        //     CHECK_THAT(f.evaluate(), Approximates(29.8125));
-        // }
-        //
-        // SECTION("Deregister all") {
-        //     FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        // }
+        SECTION("Precedence is the same") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .precedence_is_the_same("!", "~")
+                .precedence_is_the_same("*", "/")
+                .precedence_is_the_same("/", "%")
+                .precedence_is_the_same("+", "-");
+        }
+        SECTION("Precedence is higher") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .precedence_is_higher("!", "^")
+                .precedence_is_higher("^", "%")
+                .precedence_is_higher("*", "-")
+                .precedence_is_higher("+", "and")
+                .precedence_is_higher("and", "or");
+        }
 
-        // SECTION("Assign constructor") {
-        //     FunctionFactory only_operators;
-        //     for (auto function : only_operators.availableFunctions())
-        //         only_operators.deregisterObject(function);
-        //     FunctionFactory ff;
-        //     ff = only_operators;
-        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        // }
-        //
-        //         SECTION("Copy constructor with operators") {
-        //             FunctionFactory only_operators;
-        //             for (auto function : only_operators.availableFunctions())
-        //                 only_operators.deregisterObject(function);
-        //             FunctionFactory ff(only_operators);
-        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
-        //         SECTION("Copy constructor with functions") {
-        //             FunctionFactory only_functions;
-        //             for (auto operator_ : only_functions.availableOperators())
-        //                 only_functions.deregisterObject(operator_);
-        //             FunctionFactory ff(only_functions);
-        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        //         }
-        //
-        //         SECTION("Unary Operators") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .unary_operation_equals("!", &Op::logicalNot)
-        //                 .operation_is("!", 0, 1)
-        //                 .operation_is("!", 1, 0)
-        //                 .unary_operation_equals("~", &Op::negate)
-        //                 .operation_is("~", 1, -1)
-        //                 .operation_is("~", -2, 2)
-        //                 .operation_is("~", 0, 0);
-        //         }
-        //         SECTION("Binary Operators") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .binary_operation_equals("^", &std::pow)
-        //                 .operation_is("^", 3, 3, 27)
-        //                 .operation_is("^", 9, 0.5, 3)
-        //                 .binary_operation_equals("*", &Op::multiply)
-        //                 .operation_is("*", -2, 3, -6)
-        //                 .operation_is("*", 3, -2, -6)
-        //                 .operation_is("*", 0, 0, 0)
-        //                 .binary_operation_equals("/", &Op::divide)
-        //                 .operation_is("/", 6, 3, 2)
-        //                 .operation_is("/", 3, 6, 0.5)
-        //                 .operation_is("/", 0, 0, fl::nan)
-        //                 .operation_is("/", 1, 0, fl::inf)
-        //                 .operation_is("/", -1, 0, -fl::inf)
-        //                 .binary_operation_equals("%", &Op::modulo)
-        //                 .operation_is("%", 6, 3, 0)
-        //                 .operation_is("%", 3, 6, 3)
-        //                 .operation_is("%", 3.5, 6, 3.5)
-        //                 .operation_is("%", 6, 3.5, 2.5)
-        //                 .binary_operation_equals("+", &Op::add)
-        //                 .operation_is("+", 2, 3, 5)
-        //                 .operation_is("+", 2, -3, -1)
-        //                 .binary_operation_equals("-", &Op::subtract)
-        //                 .operation_is("-", 2, 3, -1)
-        //                 .operation_is("-", 2, -3, 5)
-        //                 .binary_operation_equals("and", &Op::logicalAnd)
-        //                 .operation_is("and", 1, 0, 0)
-        //                 .operation_is("and", 1, 1, 1)
-        //                 .binary_operation_equals("or", &Op::logicalOr)
-        //                 .operation_is("or", 1, 0, 1)
-        //                 .operation_is("or", 0, 0, 0);
-        //         }
-        //         SECTION("Unary functions") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .unary_operation_equals("abs", &std::abs)
-        //                 .unary_operation_equals("acos", &std::acos)
-        //                 .unary_operation_equals("asin", &std::asin)
-        //                 .unary_operation_equals("atan", &std::atan)
-        //                 .unary_operation_equals("ceil", &std::ceil)
-        //                 .unary_operation_equals("cos", &std::cos)
-        //                 .unary_operation_equals("cosh", &std::cosh)
-        //                 .unary_operation_equals("exp", &std::exp)
-        //                 .unary_operation_equals("fabs", &std::fabs)
-        //                 .unary_operation_equals("floor", &std::floor)
-        //                 .unary_operation_equals("log10", &std::log10)
-        //                 .unary_operation_equals("log", &std::log)
-        //                 .unary_operation_equals("round", &Op::round)
-        //                 .unary_operation_equals("sin", &std::sin)
-        //                 .unary_operation_equals("sinh", &std::sinh)
-        //                 .unary_operation_equals("sqrt", &std::sqrt)
-        //                 .unary_operation_equals("tan", &std::tan)
-        //                 .unary_operation_equals("tanh", &std::tanh);
-        //
-        // #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .unary_operation_equals("log1p", &log1p)
-        //                 .unary_operation_equals("acosh", &acosh)
-        //                 .unary_operation_equals("asinh", &asinh)
-        //                 .unary_operation_equals("atanh", &atanh);
-        // #endif
-        //         }
-        //
-        //         SECTION("Binary Functions") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .binary_operation_equals("atan2", &std::atan2)
-        //                 .binary_operation_equals("eq", &Op::eq)
-        //                 .binary_operation_equals("fmod", &std::fmod)
-        //                 .binary_operation_equals("ge", &Op::ge)
-        //                 .binary_operation_equals("gt", &Op::gt)
-        //                 .binary_operation_equals("le", &Op::le)
-        //                 .binary_operation_equals("lt", &Op::lt)
-        //                 .binary_operation_equals("max", &Op::max)
-        //                 .binary_operation_equals("min", &Op::min)
-        //                 .binary_operation_equals("neq", &Op::neq)
-        //                 .binary_operation_equals("pow", &std::pow);
-        //         }
+        SECTION("Precedence is correct") {
+            Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
+            f.load();
+            CHECK_THAT(f.evaluate(), Approximates(29.8125));
+        }
+
+        SECTION("Deregister all") {
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+
+        SECTION("Copy constructor with operators") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff(only_operators);
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Copy constructor with functions") {
+            FunctionFactory only_functions;
+            for (auto operator_ : only_functions.availableOperators())
+                only_functions.deregisterObject(operator_);
+            FunctionFactory ff(only_functions);
+            CHECK(ff.availableOperators() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
+
+        SECTION("Unary Operators") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("!", &Op::logicalNot)
+                .operation_is("!", 0, 1)
+                .operation_is("!", 1, 0)
+                .unary_operation_equals("~", &Op::negate)
+                .operation_is("~", 1, -1)
+                .operation_is("~", -2, 2)
+                .operation_is("~", 0, 0);
+        }
+        SECTION("Binary Operators") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .binary_operation_equals("^", &std::pow)
+                .operation_is("^", 3, 3, 27)
+                .operation_is("^", 9, 0.5, 3)
+                .binary_operation_equals("*", &Op::multiply)
+                .operation_is("*", -2, 3, -6)
+                .operation_is("*", 3, -2, -6)
+                .operation_is("*", 0, 0, 0)
+                .binary_operation_equals("/", &Op::divide)
+                .operation_is("/", 6, 3, 2)
+                .operation_is("/", 3, 6, 0.5)
+                .operation_is("/", 0, 0, fl::nan)
+                .operation_is("/", 1, 0, fl::inf)
+                .operation_is("/", -1, 0, -fl::inf)
+                .binary_operation_equals("%", &Op::modulo)
+                .operation_is("%", 6, 3, 0)
+                .operation_is("%", 3, 6, 3)
+                .operation_is("%", 3.5, 6, 3.5)
+                .operation_is("%", 6, 3.5, 2.5)
+                .binary_operation_equals("+", &Op::add)
+                .operation_is("+", 2, 3, 5)
+                .operation_is("+", 2, -3, -1)
+                .binary_operation_equals("-", &Op::subtract)
+                .operation_is("-", 2, 3, -1)
+                .operation_is("-", 2, -3, 5)
+                .binary_operation_equals("and", &Op::logicalAnd)
+                .operation_is("and", 1, 0, 0)
+                .operation_is("and", 1, 1, 1)
+                .binary_operation_equals("or", &Op::logicalOr)
+                .operation_is("or", 1, 0, 1)
+                .operation_is("or", 0, 0, 0);
+        }
+        SECTION("Unary functions") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("abs", &std::abs)
+                .unary_operation_equals("acos", &std::acos)
+                .unary_operation_equals("asin", &std::asin)
+                .unary_operation_equals("atan", &std::atan)
+                .unary_operation_equals("ceil", &std::ceil)
+                .unary_operation_equals("cos", &std::cos)
+                .unary_operation_equals("cosh", &std::cosh)
+                .unary_operation_equals("exp", &std::exp)
+                .unary_operation_equals("fabs", &std::fabs)
+                .unary_operation_equals("floor", &std::floor)
+                .unary_operation_equals("log10", &std::log10)
+                .unary_operation_equals("log", &std::log)
+                .unary_operation_equals("round", &Op::round)
+                .unary_operation_equals("sin", &std::sin)
+                .unary_operation_equals("sinh", &std::sinh)
+                .unary_operation_equals("sqrt", &std::sqrt)
+                .unary_operation_equals("tan", &std::tan)
+                .unary_operation_equals("tanh", &std::tanh);
+
+#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("log1p", &log1p)
+                .unary_operation_equals("acosh", &acosh)
+                .unary_operation_equals("asinh", &asinh)
+                .unary_operation_equals("atanh", &atanh);
+#endif
+        }
+
+        SECTION("Binary Functions") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .binary_operation_equals("atan2", &std::atan2)
+                .binary_operation_equals("eq", &Op::eq)
+                .binary_operation_equals("fmod", &std::fmod)
+                .binary_operation_equals("ge", &Op::ge)
+                .binary_operation_equals("gt", &Op::gt)
+                .binary_operation_equals("le", &Op::le)
+                .binary_operation_equals("lt", &Op::lt)
+                .binary_operation_equals("max", &Op::max)
+                .binary_operation_equals("min", &Op::min)
+                .binary_operation_equals("neq", &Op::neq)
+                .binary_operation_equals("pow", &std::pow);
+        }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -115,6 +115,33 @@ namespace fuzzylite {
             CHECK_THROWS_AS(cf.constructObject("X"), fl::Exception);
             CHECK_THROWS_WITH(cf.constructObject("X"), Catch::Matchers::StartsWith(expected));
         }
+
+        SECTION("Constructors vector") {
+            ConstructionFactory<Term*> cf("terms");
+            CHECK(cf.constructors().empty());
+            cf.registerConstructor("triangle", Triangle::constructor);
+            CHECK(cf.constructors().size() == 1);
+            CHECK(cf.constructors().find("triangle")->second == Triangle::constructor);
+
+            const ConstructionFactory<Term*> const_cf(cf);
+            CHECK(const_cf.constructors().size() == 1);
+            CHECK(const_cf.constructors().find("triangle")->second == Triangle::constructor);
+        }
+
+        SECTION("Constructor factory clones") {
+            ConstructionFactory<Term*> cf("terms");
+            cf.registerConstructor("triangle", Triangle::constructor);
+            std::unique_ptr<ConstructionFactory<Term*>> clone(cf.clone());
+            CHECK(cf.name() == "terms");
+            CHECK(clone->name() == "terms");
+
+            CHECK(cf.available() == std::vector<std::string>{"triangle"});
+            CHECK(clone->available() == std::vector<std::string>{"triangle"});
+
+            std::unique_ptr<Term> triangle(cf.constructObject("triangle"));
+            std::unique_ptr<Term> triangleClone(clone->constructObject("triangle"));
+            CHECK(triangle->toString() == triangleClone->toString());
+        }
     }
 
     struct ActivationFactoryAssert : ConstructionFactoryAssert<Activation> {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -623,6 +623,39 @@ namespace fuzzylite {
                 .operation_is("or", 0, 0, 0);
         }
 
+        SECTION("Deregister all") {
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+
+        SECTION("Copy constructor with operators") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff(only_operators);
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Copy constructor with functions") {
+            FunctionFactory only_functions;
+            for (auto operator_ : only_functions.availableOperators())
+                only_functions.deregisterObject(operator_);
+            FunctionFactory ff(only_functions);
+            CHECK(ff.availableOperators() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
+    }
+
+    TEST_CASE("Failing", "[factory]") {
         SECTION("Unary functions") {
             FunctionFactoryAssert(new FunctionFactory)
                 .unary_operation_equals("abs", &std::abs)
@@ -666,37 +699,6 @@ namespace fuzzylite {
                 .binary_operation_equals("min", &Op::min)
                 .binary_operation_equals("neq", &Op::neq)
                 .binary_operation_equals("pow", &std::pow);
-        }
-
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
-
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-
-        SECTION("Copy constructor with operators") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff(only_operators);
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Copy constructor with functions") {
-            FunctionFactory only_functions;
-            for (auto operator_ : only_functions.availableOperators())
-                only_functions.deregisterObject(operator_);
-            FunctionFactory ff(only_functions);
-            CHECK(ff.availableOperators() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
         }
     }
 

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -577,125 +577,125 @@ namespace fuzzylite {
             f.load();
             CHECK_THAT(f.evaluate(), Approximates(29.8125));
         }
-
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
-
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-
-        SECTION("Copy constructor with operators") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff(only_operators);
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Copy constructor with functions") {
-            FunctionFactory only_functions;
-            for (auto operator_ : only_functions.availableOperators())
-                only_functions.deregisterObject(operator_);
-            FunctionFactory ff(only_functions);
-            CHECK(ff.availableOperators() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        }
-
-        SECTION("Unary Operators") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("!", &Op::logicalNot)
-                .operation_is("!", 0, 1)
-                .operation_is("!", 1, 0)
-                .unary_operation_equals("~", &Op::negate)
-                .operation_is("~", 1, -1)
-                .operation_is("~", -2, 2)
-                .operation_is("~", 0, 0);
-        }
-        SECTION("Binary Operators") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .binary_operation_equals("^", &std::pow)
-                .operation_is("^", 3, 3, 27)
-                .operation_is("^", 9, 0.5, 3)
-                .binary_operation_equals("*", &Op::multiply)
-                .operation_is("*", -2, 3, -6)
-                .operation_is("*", 3, -2, -6)
-                .operation_is("*", 0, 0, 0)
-                .binary_operation_equals("/", &Op::divide)
-                .operation_is("/", 6, 3, 2)
-                .operation_is("/", 3, 6, 0.5)
-                .operation_is("/", 0, 0, fl::nan)
-                .operation_is("/", 1, 0, fl::inf)
-                .operation_is("/", -1, 0, -fl::inf)
-                .binary_operation_equals("%", &Op::modulo)
-                .operation_is("%", 6, 3, 0)
-                .operation_is("%", 3, 6, 3)
-                .operation_is("%", 3.5, 6, 3.5)
-                .operation_is("%", 6, 3.5, 2.5)
-                .binary_operation_equals("+", &Op::add)
-                .operation_is("+", 2, 3, 5)
-                .operation_is("+", 2, -3, -1)
-                .binary_operation_equals("-", &Op::subtract)
-                .operation_is("-", 2, 3, -1)
-                .operation_is("-", 2, -3, 5)
-                .binary_operation_equals("and", &Op::logicalAnd)
-                .operation_is("and", 1, 0, 0)
-                .operation_is("and", 1, 1, 1)
-                .binary_operation_equals("or", &Op::logicalOr)
-                .operation_is("or", 1, 0, 1)
-                .operation_is("or", 0, 0, 0);
-        }
-        SECTION("Unary functions") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("abs", &std::abs)
-                .unary_operation_equals("acos", &std::acos)
-                .unary_operation_equals("asin", &std::asin)
-                .unary_operation_equals("atan", &std::atan)
-                .unary_operation_equals("ceil", &std::ceil)
-                .unary_operation_equals("cos", &std::cos)
-                .unary_operation_equals("cosh", &std::cosh)
-                .unary_operation_equals("exp", &std::exp)
-                .unary_operation_equals("fabs", &std::fabs)
-                .unary_operation_equals("floor", &std::floor)
-                .unary_operation_equals("log10", &std::log10)
-                .unary_operation_equals("log", &std::log)
-                .unary_operation_equals("round", &Op::round)
-                .unary_operation_equals("sin", &std::sin)
-                .unary_operation_equals("sinh", &std::sinh)
-                .unary_operation_equals("sqrt", &std::sqrt)
-                .unary_operation_equals("tan", &std::tan)
-                .unary_operation_equals("tanh", &std::tanh);
-
-#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("log1p", &log1p)
-                .unary_operation_equals("acosh", &acosh)
-                .unary_operation_equals("asinh", &asinh)
-                .unary_operation_equals("atanh", &atanh);
-#endif
-        }
-
-        SECTION("Binary Functions") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .binary_operation_equals("atan2", &std::atan2)
-                .binary_operation_equals("eq", &Op::eq)
-                .binary_operation_equals("fmod", &std::fmod)
-                .binary_operation_equals("ge", &Op::ge)
-                .binary_operation_equals("gt", &Op::gt)
-                .binary_operation_equals("le", &Op::le)
-                .binary_operation_equals("lt", &Op::lt)
-                .binary_operation_equals("max", &Op::max)
-                .binary_operation_equals("min", &Op::min)
-                .binary_operation_equals("neq", &Op::neq)
-                .binary_operation_equals("pow", &std::pow);
-        }
+//
+//         SECTION("Deregister all") {
+//             FunctionFactoryAssert(new FunctionFactory).deregister_all();
+//         }
+//
+//         SECTION("Assign constructor") {
+//             FunctionFactory only_operators;
+//             for (auto function : only_operators.availableFunctions())
+//                 only_operators.deregisterObject(function);
+//             FunctionFactory ff;
+//             ff = only_operators;
+//             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+//             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+//         }
+//
+//         SECTION("Copy constructor with operators") {
+//             FunctionFactory only_operators;
+//             for (auto function : only_operators.availableFunctions())
+//                 only_operators.deregisterObject(function);
+//             FunctionFactory ff(only_operators);
+//             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+//             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+//         }
+//         SECTION("Copy constructor with functions") {
+//             FunctionFactory only_functions;
+//             for (auto operator_ : only_functions.availableOperators())
+//                 only_functions.deregisterObject(operator_);
+//             FunctionFactory ff(only_functions);
+//             CHECK(ff.availableOperators() == std::vector<std::string>{});
+//             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+//         }
+//
+//         SECTION("Unary Operators") {
+//             FunctionFactoryAssert(new FunctionFactory)
+//                 .unary_operation_equals("!", &Op::logicalNot)
+//                 .operation_is("!", 0, 1)
+//                 .operation_is("!", 1, 0)
+//                 .unary_operation_equals("~", &Op::negate)
+//                 .operation_is("~", 1, -1)
+//                 .operation_is("~", -2, 2)
+//                 .operation_is("~", 0, 0);
+//         }
+//         SECTION("Binary Operators") {
+//             FunctionFactoryAssert(new FunctionFactory)
+//                 .binary_operation_equals("^", &std::pow)
+//                 .operation_is("^", 3, 3, 27)
+//                 .operation_is("^", 9, 0.5, 3)
+//                 .binary_operation_equals("*", &Op::multiply)
+//                 .operation_is("*", -2, 3, -6)
+//                 .operation_is("*", 3, -2, -6)
+//                 .operation_is("*", 0, 0, 0)
+//                 .binary_operation_equals("/", &Op::divide)
+//                 .operation_is("/", 6, 3, 2)
+//                 .operation_is("/", 3, 6, 0.5)
+//                 .operation_is("/", 0, 0, fl::nan)
+//                 .operation_is("/", 1, 0, fl::inf)
+//                 .operation_is("/", -1, 0, -fl::inf)
+//                 .binary_operation_equals("%", &Op::modulo)
+//                 .operation_is("%", 6, 3, 0)
+//                 .operation_is("%", 3, 6, 3)
+//                 .operation_is("%", 3.5, 6, 3.5)
+//                 .operation_is("%", 6, 3.5, 2.5)
+//                 .binary_operation_equals("+", &Op::add)
+//                 .operation_is("+", 2, 3, 5)
+//                 .operation_is("+", 2, -3, -1)
+//                 .binary_operation_equals("-", &Op::subtract)
+//                 .operation_is("-", 2, 3, -1)
+//                 .operation_is("-", 2, -3, 5)
+//                 .binary_operation_equals("and", &Op::logicalAnd)
+//                 .operation_is("and", 1, 0, 0)
+//                 .operation_is("and", 1, 1, 1)
+//                 .binary_operation_equals("or", &Op::logicalOr)
+//                 .operation_is("or", 1, 0, 1)
+//                 .operation_is("or", 0, 0, 0);
+//         }
+//         SECTION("Unary functions") {
+//             FunctionFactoryAssert(new FunctionFactory)
+//                 .unary_operation_equals("abs", &std::abs)
+//                 .unary_operation_equals("acos", &std::acos)
+//                 .unary_operation_equals("asin", &std::asin)
+//                 .unary_operation_equals("atan", &std::atan)
+//                 .unary_operation_equals("ceil", &std::ceil)
+//                 .unary_operation_equals("cos", &std::cos)
+//                 .unary_operation_equals("cosh", &std::cosh)
+//                 .unary_operation_equals("exp", &std::exp)
+//                 .unary_operation_equals("fabs", &std::fabs)
+//                 .unary_operation_equals("floor", &std::floor)
+//                 .unary_operation_equals("log10", &std::log10)
+//                 .unary_operation_equals("log", &std::log)
+//                 .unary_operation_equals("round", &Op::round)
+//                 .unary_operation_equals("sin", &std::sin)
+//                 .unary_operation_equals("sinh", &std::sinh)
+//                 .unary_operation_equals("sqrt", &std::sqrt)
+//                 .unary_operation_equals("tan", &std::tan)
+//                 .unary_operation_equals("tanh", &std::tanh);
+//
+// #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
+//             FunctionFactoryAssert(new FunctionFactory)
+//                 .unary_operation_equals("log1p", &log1p)
+//                 .unary_operation_equals("acosh", &acosh)
+//                 .unary_operation_equals("asinh", &asinh)
+//                 .unary_operation_equals("atanh", &atanh);
+// #endif
+//         }
+//
+//         SECTION("Binary Functions") {
+//             FunctionFactoryAssert(new FunctionFactory)
+//                 .binary_operation_equals("atan2", &std::atan2)
+//                 .binary_operation_equals("eq", &Op::eq)
+//                 .binary_operation_equals("fmod", &std::fmod)
+//                 .binary_operation_equals("ge", &Op::ge)
+//                 .binary_operation_equals("gt", &Op::gt)
+//                 .binary_operation_equals("le", &Op::le)
+//                 .binary_operation_equals("lt", &Op::lt)
+//                 .binary_operation_equals("max", &Op::max)
+//                 .binary_operation_equals("min", &Op::min)
+//                 .binary_operation_equals("neq", &Op::neq)
+//                 .binary_operation_equals("pow", &std::pow);
+//         }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -668,18 +668,18 @@ namespace fuzzylite {
             CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
         }
 
-        // SECTION("Deregister all") {
-        //     FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        // }
-        // SECTION("Assign constructor") {
-        //     FunctionFactory only_operators;
-        //     for (auto function : only_operators.availableFunctions())
-        //         only_operators.deregisterObject(function);
-        //     FunctionFactory ff;
-        //     ff = only_operators;
-        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        // }
+        SECTION("Deregister all") {
+            // FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
         //
         //         SECTION("Copy constructor with operators") {
         //             FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -533,8 +533,11 @@ namespace fuzzylite {
     TEST_CASE("FunctionFactory", "[factory][function]") {
         SECTION("Cloning empty object returns null") {
             FunctionFactory ff;
+            ff.clear();
             ff.registerObject("null", fl::null);
             CHECK(ff.cloneObject("null") == fl::null);
+            ff.deregisterObject("null");
+            CHECK(ff.available().empty());
         }
 
         SECTION("Operators available") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -674,33 +674,32 @@ namespace fuzzylite {
         SECTION("Deregister all") {
             FunctionFactoryAssert(new FunctionFactory).deregister_all();
         }
-        // SECTION("Assign constructor") {
-        //     FunctionFactory only_operators;
-        //     for (auto function : only_operators.availableFunctions())
-        //         only_operators.deregisterObject(function);
-        //     FunctionFactory ff;
-        //     ff = only_operators;
-        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        // }
-        //
-        //         SECTION("Copy constructor with operators") {
-        //             FunctionFactory only_operators;
-        //             for (auto function : only_operators.availableFunctions())
-        //                 only_operators.deregisterObject(function);
-        //             FunctionFactory ff(only_operators);
-        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
-        //         SECTION("Copy constructor with functions") {
-        //             FunctionFactory only_functions;
-        //             for (auto operator_ : only_functions.availableOperators())
-        //                 only_functions.deregisterObject(operator_);
-        //             FunctionFactory ff(only_functions);
-        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        //         }
-        //
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+
+        SECTION("Copy constructor with operators") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff(only_operators);
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Copy constructor with functions") {
+            FunctionFactory only_functions;
+            for (auto operator_ : only_functions.availableOperators())
+                only_functions.deregisterObject(operator_);
+            FunctionFactory ff(only_functions);
+            CHECK(ff.availableOperators() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -431,11 +431,10 @@ namespace fuzzylite {
             for (const auto& clone : actual->available()) {
                 CAPTURE(clone);
                 CHECK(actual->hasObject(clone));
-                // actual->deregisterObject(clone);
-                // CHECK(not actual->hasObject(clone));
+                actual->deregisterObject(clone);
+                CHECK(not actual->hasObject(clone));
             }
-            // CHECK(actual->objects().empty());
-            actual->objects().clear();
+            CHECK(actual->objects().empty());
             return *this;
         }
     };

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -536,18 +536,18 @@ namespace fuzzylite {
             ff.registerObject("null", fl::null);
             CHECK(ff.cloneObject("null") == fl::null);
         }
-        SECTION("Cloning unregistered object raises exception") {
-            const std::string expected = "[cloning error] Function object by name <X> not registered";
-            FunctionFactory ff;
-            CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
-            CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
+        // SECTION("Cloning unregistered object raises exception") {
+        //     const std::string expected = "[cloning error] Function object by name <X> not registered";
+        //     FunctionFactory ff;
+        //     CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
+        //     CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
+        // }
+        SECTION("Operators available") {
+            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
         }
-        // SECTION("Operators available") {
-        //     CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        // }
-        // SECTION("Functions available") {
-        //     CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        // }
+        SECTION("Functions available") {
+            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
 
         // SECTION("Available") {
         //     std::vector<std::string> expected;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -579,6 +579,39 @@ namespace fuzzylite {
             CHECK_THAT(f.evaluate(), Approximates(29.8125));
         }
 
+        SECTION("Deregister all") {
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+
+        SECTION("Assign constructor") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff;
+            ff = only_operators;
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+
+        SECTION("Copy constructor with operators") {
+            FunctionFactory only_operators;
+            for (auto function : only_operators.availableFunctions())
+                only_operators.deregisterObject(function);
+            FunctionFactory ff(only_operators);
+            CHECK(ff.availableFunctions() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Copy constructor with functions") {
+            FunctionFactory only_functions;
+            for (auto operator_ : only_functions.availableOperators())
+                only_functions.deregisterObject(operator_);
+            FunctionFactory ff(only_functions);
+            CHECK(ff.availableOperators() == std::vector<std::string>{});
+            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
+    }
+
+    TEST_CASE("Failing", "[factory]") {
         SECTION("Unary Operators") {
             FunctionFactoryAssert(new FunctionFactory)
                 .unary_operation_equals("!", &Op::logicalNot)
@@ -622,40 +655,6 @@ namespace fuzzylite {
                 .operation_is("or", 1, 0, 1)
                 .operation_is("or", 0, 0, 0);
         }
-
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
-
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-
-        SECTION("Copy constructor with operators") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff(only_operators);
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Copy constructor with functions") {
-            FunctionFactory only_functions;
-            for (auto operator_ : only_functions.availableOperators())
-                only_functions.deregisterObject(operator_);
-            FunctionFactory ff(only_functions);
-            CHECK(ff.availableOperators() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        }
-    }
-
-    TEST_CASE("Failing", "[factory]") {
         SECTION("Unary functions") {
             FunctionFactoryAssert(new FunctionFactory)
                 .unary_operation_equals("abs", &std::abs)
@@ -715,31 +714,31 @@ namespace fuzzylite {
         }
 
         struct CustomTNormFactory : TNormFactory {
-            CustomTNormFactory() : TNormFactory("CustomTNorm"){};
+            CustomTNormFactory() : TNormFactory("CustomTNorm") {}
         };
 
         struct CustomSNormFactory : SNormFactory {
-            CustomSNormFactory() : SNormFactory("CustomSNorm"){};
+            CustomSNormFactory() : SNormFactory("CustomSNorm") {}
         };
 
         struct CustomDefuzziferFactory : DefuzzifierFactory {
-            CustomDefuzziferFactory() : DefuzzifierFactory("CustomDefuzzifier"){};
+            CustomDefuzziferFactory() : DefuzzifierFactory("CustomDefuzzifier") {}
         };
 
         struct CustomHedgeFactory : HedgeFactory {
-            CustomHedgeFactory() : HedgeFactory("CustomHedge"){};
+            CustomHedgeFactory() : HedgeFactory("CustomHedge") {}
         };
 
         struct CustomActivationFactory : ActivationFactory {
-            CustomActivationFactory() : ActivationFactory("CustomActivation"){};
+            CustomActivationFactory() : ActivationFactory("CustomActivation") {}
         };
 
         struct CustomTermFactory : TermFactory {
-            CustomTermFactory() : TermFactory("CustomTerm"){};
+            CustomTermFactory() : TermFactory("CustomTerm") {}
         };
 
         struct CustomFunctionFactory : FunctionFactory {
-            CustomFunctionFactory() : FunctionFactory("CustomFunction"){};
+            CustomFunctionFactory() : FunctionFactory("CustomFunction") {}
         };
 
         SECTION("Constructor of Custom factories") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -671,15 +671,15 @@ namespace fuzzylite {
         SECTION("Deregister all") {
             // FunctionFactoryAssert(new FunctionFactory).deregister_all();
         }
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
+        // SECTION("Assign constructor") {
+        //     FunctionFactory only_operators;
+        //     for (auto function : only_operators.availableFunctions())
+        //         only_operators.deregisterObject(function);
+        //     FunctionFactory ff;
+        //     ff = only_operators;
+        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        // }
         //
         //         SECTION("Copy constructor with operators") {
         //             FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -536,61 +536,61 @@ namespace fuzzylite {
             ff.registerObject("null", fl::null);
             CHECK(ff.cloneObject("null") == fl::null);
         }
-        //         SECTION("Cloning unregistered object raises exception") {
-        //             const std::string expected = "[cloning error] Function object by name <X> not registered";
-        //             FunctionFactory ff;
-        //             CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
-        //             CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
-        //         }
-        //         SECTION("Operators available") {
-        //             CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
-        //         SECTION("Functions available") {
-        //             CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        //         }
-        //
-        //         SECTION("Available") {
-        //             std::vector<std::string> expected;
-        //             std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
-        //             std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
-        //             CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
-        //         }
-        //
-        //         SECTION("Precedence is the same") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .precedence_is_the_same("!", "~")
-        //                 .precedence_is_the_same("*", "/")
-        //                 .precedence_is_the_same("/", "%")
-        //                 .precedence_is_the_same("+", "-");
-        //         }
-        //         SECTION("Precedence is higher") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .precedence_is_higher("!", "^")
-        //                 .precedence_is_higher("^", "%")
-        //                 .precedence_is_higher("*", "-")
-        //                 .precedence_is_higher("+", "and")
-        //                 .precedence_is_higher("and", "or");
-        //         }
-        //
-        //         SECTION("Precedence is correct") {
-        //             Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
-        //             f.load();
-        //             CHECK_THAT(f.evaluate(), Approximates(29.8125));
-        //         }
-        //
-        //         SECTION("Deregister all") {
-        //             FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        //         }
-        //
-        //         SECTION("Assign constructor") {
-        //             FunctionFactory only_operators;
-        //             for (auto function : only_operators.availableFunctions())
-        //                 only_operators.deregisterObject(function);
-        //             FunctionFactory ff;
-        //             ff = only_operators;
-        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        //         }
+        SECTION("Cloning unregistered object raises exception") {
+            const std::string expected = "[cloning error] Function object by name <X> not registered";
+            FunctionFactory ff;
+            CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
+            CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
+        }
+        SECTION("Operators available") {
+            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        }
+        SECTION("Functions available") {
+            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        }
+
+        SECTION("Available") {
+            std::vector<std::string> expected;
+            std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
+            std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
+            CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
+        }
+
+        SECTION("Precedence is the same") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .precedence_is_the_same("!", "~")
+                .precedence_is_the_same("*", "/")
+                .precedence_is_the_same("/", "%")
+                .precedence_is_the_same("+", "-");
+        }
+        SECTION("Precedence is higher") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .precedence_is_higher("!", "^")
+                .precedence_is_higher("^", "%")
+                .precedence_is_higher("*", "-")
+                .precedence_is_higher("+", "and")
+                .precedence_is_higher("and", "or");
+        }
+
+        SECTION("Precedence is correct") {
+            Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
+            f.load();
+            CHECK_THAT(f.evaluate(), Approximates(29.8125));
+        }
+
+        SECTION("Deregister all") {
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        }
+
+        // SECTION("Assign constructor") {
+        //     FunctionFactory only_operators;
+        //     for (auto function : only_operators.availableFunctions())
+        //         only_operators.deregisterObject(function);
+        //     FunctionFactory ff;
+        //     ff = only_operators;
+        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        // }
         //
         //         SECTION("Copy constructor with operators") {
         //             FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -536,12 +536,7 @@ namespace fuzzylite {
             ff.registerObject("null", fl::null);
             CHECK(ff.cloneObject("null") == fl::null);
         }
-        // SECTION("Cloning unregistered object raises exception") {
-        //     const std::string expected = "[cloning error] Function object by name <X> not registered";
-        //     FunctionFactory ff;
-        //     CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
-        //     CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
-        // }
+
         SECTION("Operators available") {
             CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
         }
@@ -666,18 +661,25 @@ namespace fuzzylite {
                 .binary_operation_equals("pow", &std::pow);
         }
 
+        SECTION("Cloning unregistered object raises exception") {
+            const std::string expected = "[cloning error] Function object by name <X> not registered";
+            FunctionFactory ff;
+            CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
+            CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
+        }
+
         // SECTION("Deregister all") {
         //     FunctionFactoryAssert(new FunctionFactory).deregister_all();
         // }
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
+        // SECTION("Assign constructor") {
+        //     FunctionFactory only_operators;
+        //     for (auto function : only_operators.availableFunctions())
+        //         only_operators.deregisterObject(function);
+        //     FunctionFactory ff;
+        //     ff = only_operators;
+        //     CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //     CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        // }
         //
         //         SECTION("Copy constructor with operators") {
         //             FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -669,7 +669,7 @@ namespace fuzzylite {
         }
 
         SECTION("Deregister all") {
-            // FunctionFactoryAssert(new FunctionFactory).deregister_all();
+            FunctionFactoryAssert(new FunctionFactory).deregister_all();
         }
         // SECTION("Assign constructor") {
         //     FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -536,166 +536,166 @@ namespace fuzzylite {
             ff.registerObject("null", fl::null);
             CHECK(ff.cloneObject("null") == fl::null);
         }
-        SECTION("Cloning unregistered object raises exception") {
-            const std::string expected = "[cloning error] Function object by name <X> not registered";
-            FunctionFactory ff;
-            CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
-            CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
-        }
-        SECTION("Operators available") {
-            CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Functions available") {
-            CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        }
-
-        SECTION("Available") {
-            std::vector<std::string> expected;
-            std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
-            std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
-            CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
-        }
-
-        SECTION("Precedence is the same") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .precedence_is_the_same("!", "~")
-                .precedence_is_the_same("*", "/")
-                .precedence_is_the_same("/", "%")
-                .precedence_is_the_same("+", "-");
-        }
-        SECTION("Precedence is higher") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .precedence_is_higher("!", "^")
-                .precedence_is_higher("^", "%")
-                .precedence_is_higher("*", "-")
-                .precedence_is_higher("+", "and")
-                .precedence_is_higher("and", "or");
-        }
-
-        SECTION("Precedence is correct") {
-            Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
-            f.load();
-            CHECK_THAT(f.evaluate(), Approximates(29.8125));
-        }
-
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
-
-        SECTION("Assign constructor") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff;
-            ff = only_operators;
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-
-        SECTION("Copy constructor with operators") {
-            FunctionFactory only_operators;
-            for (auto function : only_operators.availableFunctions())
-                only_operators.deregisterObject(function);
-            FunctionFactory ff(only_operators);
-            CHECK(ff.availableFunctions() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-        }
-        SECTION("Copy constructor with functions") {
-            FunctionFactory only_functions;
-            for (auto operator_ : only_functions.availableOperators())
-                only_functions.deregisterObject(operator_);
-            FunctionFactory ff(only_functions);
-            CHECK(ff.availableOperators() == std::vector<std::string>{});
-            CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-        }
-
-        SECTION("Unary Operators") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("!", &Op::logicalNot)
-                .operation_is("!", 0, 1)
-                .operation_is("!", 1, 0)
-                .unary_operation_equals("~", &Op::negate)
-                .operation_is("~", 1, -1)
-                .operation_is("~", -2, 2)
-                .operation_is("~", 0, 0);
-        }
-        SECTION("Binary Operators") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .binary_operation_equals("^", &std::pow)
-                .operation_is("^", 3, 3, 27)
-                .operation_is("^", 9, 0.5, 3)
-                .binary_operation_equals("*", &Op::multiply)
-                .operation_is("*", -2, 3, -6)
-                .operation_is("*", 3, -2, -6)
-                .operation_is("*", 0, 0, 0)
-                .binary_operation_equals("/", &Op::divide)
-                .operation_is("/", 6, 3, 2)
-                .operation_is("/", 3, 6, 0.5)
-                .operation_is("/", 0, 0, fl::nan)
-                .operation_is("/", 1, 0, fl::inf)
-                .operation_is("/", -1, 0, -fl::inf)
-                .binary_operation_equals("%", &Op::modulo)
-                .operation_is("%", 6, 3, 0)
-                .operation_is("%", 3, 6, 3)
-                .operation_is("%", 3.5, 6, 3.5)
-                .operation_is("%", 6, 3.5, 2.5)
-                .binary_operation_equals("+", &Op::add)
-                .operation_is("+", 2, 3, 5)
-                .operation_is("+", 2, -3, -1)
-                .binary_operation_equals("-", &Op::subtract)
-                .operation_is("-", 2, 3, -1)
-                .operation_is("-", 2, -3, 5)
-                .binary_operation_equals("and", &Op::logicalAnd)
-                .operation_is("and", 1, 0, 0)
-                .operation_is("and", 1, 1, 1)
-                .binary_operation_equals("or", &Op::logicalOr)
-                .operation_is("or", 1, 0, 1)
-                .operation_is("or", 0, 0, 0);
-        }
-        SECTION("Unary functions") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("abs", &std::abs)
-                .unary_operation_equals("acos", &std::acos)
-                .unary_operation_equals("asin", &std::asin)
-                .unary_operation_equals("atan", &std::atan)
-                .unary_operation_equals("ceil", &std::ceil)
-                .unary_operation_equals("cos", &std::cos)
-                .unary_operation_equals("cosh", &std::cosh)
-                .unary_operation_equals("exp", &std::exp)
-                .unary_operation_equals("fabs", &std::fabs)
-                .unary_operation_equals("floor", &std::floor)
-                .unary_operation_equals("log10", &std::log10)
-                .unary_operation_equals("log", &std::log)
-                .unary_operation_equals("round", &Op::round)
-                .unary_operation_equals("sin", &std::sin)
-                .unary_operation_equals("sinh", &std::sinh)
-                .unary_operation_equals("sqrt", &std::sqrt)
-                .unary_operation_equals("tan", &std::tan)
-                .unary_operation_equals("tanh", &std::tanh);
-
-#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
-            FunctionFactoryAssert(new FunctionFactory)
-                .unary_operation_equals("log1p", &log1p)
-                .unary_operation_equals("acosh", &acosh)
-                .unary_operation_equals("asinh", &asinh)
-                .unary_operation_equals("atanh", &atanh);
-#endif
-        }
-
-        SECTION("Binary Functions") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .binary_operation_equals("atan2", &std::atan2)
-                .binary_operation_equals("eq", &Op::eq)
-                .binary_operation_equals("fmod", &std::fmod)
-                .binary_operation_equals("ge", &Op::ge)
-                .binary_operation_equals("gt", &Op::gt)
-                .binary_operation_equals("le", &Op::le)
-                .binary_operation_equals("lt", &Op::lt)
-                .binary_operation_equals("max", &Op::max)
-                .binary_operation_equals("min", &Op::min)
-                .binary_operation_equals("neq", &Op::neq)
-                .binary_operation_equals("pow", &std::pow);
-        }
+        //         SECTION("Cloning unregistered object raises exception") {
+        //             const std::string expected = "[cloning error] Function object by name <X> not registered";
+        //             FunctionFactory ff;
+        //             CHECK_THROWS_AS(ff.cloneObject("X"), fl::Exception);
+        //             CHECK_THROWS_WITH(ff.cloneObject("X"), Catch::Matchers::StartsWith(expected));
+        //         }
+        //         SECTION("Operators available") {
+        //             CHECK_THAT(FunctionFactory().availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //         SECTION("Functions available") {
+        //             CHECK_THAT(FunctionFactory().availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        //         }
+        //
+        //         SECTION("Available") {
+        //             std::vector<std::string> expected;
+        //             std::copy(operators.begin(), operators.end(), std::back_inserter(expected));
+        //             std::copy(functions.begin(), functions.end(), std::back_inserter(expected));
+        //             CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
+        //         }
+        //
+        //         SECTION("Precedence is the same") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .precedence_is_the_same("!", "~")
+        //                 .precedence_is_the_same("*", "/")
+        //                 .precedence_is_the_same("/", "%")
+        //                 .precedence_is_the_same("+", "-");
+        //         }
+        //         SECTION("Precedence is higher") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .precedence_is_higher("!", "^")
+        //                 .precedence_is_higher("^", "%")
+        //                 .precedence_is_higher("*", "-")
+        //                 .precedence_is_higher("+", "and")
+        //                 .precedence_is_higher("and", "or");
+        //         }
+        //
+        //         SECTION("Precedence is correct") {
+        //             Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
+        //             f.load();
+        //             CHECK_THAT(f.evaluate(), Approximates(29.8125));
+        //         }
+        //
+        //         SECTION("Deregister all") {
+        //             FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        //         }
+        //
+        //         SECTION("Assign constructor") {
+        //             FunctionFactory only_operators;
+        //             for (auto function : only_operators.availableFunctions())
+        //                 only_operators.deregisterObject(function);
+        //             FunctionFactory ff;
+        //             ff = only_operators;
+        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //
+        //         SECTION("Copy constructor with operators") {
+        //             FunctionFactory only_operators;
+        //             for (auto function : only_operators.availableFunctions())
+        //                 only_operators.deregisterObject(function);
+        //             FunctionFactory ff(only_operators);
+        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //         SECTION("Copy constructor with functions") {
+        //             FunctionFactory only_functions;
+        //             for (auto operator_ : only_functions.availableOperators())
+        //                 only_functions.deregisterObject(operator_);
+        //             FunctionFactory ff(only_functions);
+        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        //         }
+        //
+        //         SECTION("Unary Operators") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .unary_operation_equals("!", &Op::logicalNot)
+        //                 .operation_is("!", 0, 1)
+        //                 .operation_is("!", 1, 0)
+        //                 .unary_operation_equals("~", &Op::negate)
+        //                 .operation_is("~", 1, -1)
+        //                 .operation_is("~", -2, 2)
+        //                 .operation_is("~", 0, 0);
+        //         }
+        //         SECTION("Binary Operators") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .binary_operation_equals("^", &std::pow)
+        //                 .operation_is("^", 3, 3, 27)
+        //                 .operation_is("^", 9, 0.5, 3)
+        //                 .binary_operation_equals("*", &Op::multiply)
+        //                 .operation_is("*", -2, 3, -6)
+        //                 .operation_is("*", 3, -2, -6)
+        //                 .operation_is("*", 0, 0, 0)
+        //                 .binary_operation_equals("/", &Op::divide)
+        //                 .operation_is("/", 6, 3, 2)
+        //                 .operation_is("/", 3, 6, 0.5)
+        //                 .operation_is("/", 0, 0, fl::nan)
+        //                 .operation_is("/", 1, 0, fl::inf)
+        //                 .operation_is("/", -1, 0, -fl::inf)
+        //                 .binary_operation_equals("%", &Op::modulo)
+        //                 .operation_is("%", 6, 3, 0)
+        //                 .operation_is("%", 3, 6, 3)
+        //                 .operation_is("%", 3.5, 6, 3.5)
+        //                 .operation_is("%", 6, 3.5, 2.5)
+        //                 .binary_operation_equals("+", &Op::add)
+        //                 .operation_is("+", 2, 3, 5)
+        //                 .operation_is("+", 2, -3, -1)
+        //                 .binary_operation_equals("-", &Op::subtract)
+        //                 .operation_is("-", 2, 3, -1)
+        //                 .operation_is("-", 2, -3, 5)
+        //                 .binary_operation_equals("and", &Op::logicalAnd)
+        //                 .operation_is("and", 1, 0, 0)
+        //                 .operation_is("and", 1, 1, 1)
+        //                 .binary_operation_equals("or", &Op::logicalOr)
+        //                 .operation_is("or", 1, 0, 1)
+        //                 .operation_is("or", 0, 0, 0);
+        //         }
+        //         SECTION("Unary functions") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .unary_operation_equals("abs", &std::abs)
+        //                 .unary_operation_equals("acos", &std::acos)
+        //                 .unary_operation_equals("asin", &std::asin)
+        //                 .unary_operation_equals("atan", &std::atan)
+        //                 .unary_operation_equals("ceil", &std::ceil)
+        //                 .unary_operation_equals("cos", &std::cos)
+        //                 .unary_operation_equals("cosh", &std::cosh)
+        //                 .unary_operation_equals("exp", &std::exp)
+        //                 .unary_operation_equals("fabs", &std::fabs)
+        //                 .unary_operation_equals("floor", &std::floor)
+        //                 .unary_operation_equals("log10", &std::log10)
+        //                 .unary_operation_equals("log", &std::log)
+        //                 .unary_operation_equals("round", &Op::round)
+        //                 .unary_operation_equals("sin", &std::sin)
+        //                 .unary_operation_equals("sinh", &std::sinh)
+        //                 .unary_operation_equals("sqrt", &std::sqrt)
+        //                 .unary_operation_equals("tan", &std::tan)
+        //                 .unary_operation_equals("tanh", &std::tanh);
+        //
+        // #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .unary_operation_equals("log1p", &log1p)
+        //                 .unary_operation_equals("acosh", &acosh)
+        //                 .unary_operation_equals("asinh", &asinh)
+        //                 .unary_operation_equals("atanh", &atanh);
+        // #endif
+        //         }
+        //
+        //         SECTION("Binary Functions") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .binary_operation_equals("atan2", &std::atan2)
+        //                 .binary_operation_equals("eq", &Op::eq)
+        //                 .binary_operation_equals("fmod", &std::fmod)
+        //                 .binary_operation_equals("ge", &Op::ge)
+        //                 .binary_operation_equals("gt", &Op::gt)
+        //                 .binary_operation_equals("le", &Op::le)
+        //                 .binary_operation_equals("lt", &Op::lt)
+        //                 .binary_operation_equals("max", &Op::max)
+        //                 .binary_operation_equals("min", &Op::min)
+        //                 .binary_operation_equals("neq", &Op::neq)
+        //                 .binary_operation_equals("pow", &std::pow);
+        //         }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -577,125 +577,125 @@ namespace fuzzylite {
             f.load();
             CHECK_THAT(f.evaluate(), Approximates(29.8125));
         }
-//
-//         SECTION("Deregister all") {
-//             FunctionFactoryAssert(new FunctionFactory).deregister_all();
-//         }
-//
-//         SECTION("Assign constructor") {
-//             FunctionFactory only_operators;
-//             for (auto function : only_operators.availableFunctions())
-//                 only_operators.deregisterObject(function);
-//             FunctionFactory ff;
-//             ff = only_operators;
-//             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-//             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-//         }
-//
-//         SECTION("Copy constructor with operators") {
-//             FunctionFactory only_operators;
-//             for (auto function : only_operators.availableFunctions())
-//                 only_operators.deregisterObject(function);
-//             FunctionFactory ff(only_operators);
-//             CHECK(ff.availableFunctions() == std::vector<std::string>{});
-//             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
-//         }
-//         SECTION("Copy constructor with functions") {
-//             FunctionFactory only_functions;
-//             for (auto operator_ : only_functions.availableOperators())
-//                 only_functions.deregisterObject(operator_);
-//             FunctionFactory ff(only_functions);
-//             CHECK(ff.availableOperators() == std::vector<std::string>{});
-//             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
-//         }
-//
-//         SECTION("Unary Operators") {
-//             FunctionFactoryAssert(new FunctionFactory)
-//                 .unary_operation_equals("!", &Op::logicalNot)
-//                 .operation_is("!", 0, 1)
-//                 .operation_is("!", 1, 0)
-//                 .unary_operation_equals("~", &Op::negate)
-//                 .operation_is("~", 1, -1)
-//                 .operation_is("~", -2, 2)
-//                 .operation_is("~", 0, 0);
-//         }
-//         SECTION("Binary Operators") {
-//             FunctionFactoryAssert(new FunctionFactory)
-//                 .binary_operation_equals("^", &std::pow)
-//                 .operation_is("^", 3, 3, 27)
-//                 .operation_is("^", 9, 0.5, 3)
-//                 .binary_operation_equals("*", &Op::multiply)
-//                 .operation_is("*", -2, 3, -6)
-//                 .operation_is("*", 3, -2, -6)
-//                 .operation_is("*", 0, 0, 0)
-//                 .binary_operation_equals("/", &Op::divide)
-//                 .operation_is("/", 6, 3, 2)
-//                 .operation_is("/", 3, 6, 0.5)
-//                 .operation_is("/", 0, 0, fl::nan)
-//                 .operation_is("/", 1, 0, fl::inf)
-//                 .operation_is("/", -1, 0, -fl::inf)
-//                 .binary_operation_equals("%", &Op::modulo)
-//                 .operation_is("%", 6, 3, 0)
-//                 .operation_is("%", 3, 6, 3)
-//                 .operation_is("%", 3.5, 6, 3.5)
-//                 .operation_is("%", 6, 3.5, 2.5)
-//                 .binary_operation_equals("+", &Op::add)
-//                 .operation_is("+", 2, 3, 5)
-//                 .operation_is("+", 2, -3, -1)
-//                 .binary_operation_equals("-", &Op::subtract)
-//                 .operation_is("-", 2, 3, -1)
-//                 .operation_is("-", 2, -3, 5)
-//                 .binary_operation_equals("and", &Op::logicalAnd)
-//                 .operation_is("and", 1, 0, 0)
-//                 .operation_is("and", 1, 1, 1)
-//                 .binary_operation_equals("or", &Op::logicalOr)
-//                 .operation_is("or", 1, 0, 1)
-//                 .operation_is("or", 0, 0, 0);
-//         }
-//         SECTION("Unary functions") {
-//             FunctionFactoryAssert(new FunctionFactory)
-//                 .unary_operation_equals("abs", &std::abs)
-//                 .unary_operation_equals("acos", &std::acos)
-//                 .unary_operation_equals("asin", &std::asin)
-//                 .unary_operation_equals("atan", &std::atan)
-//                 .unary_operation_equals("ceil", &std::ceil)
-//                 .unary_operation_equals("cos", &std::cos)
-//                 .unary_operation_equals("cosh", &std::cosh)
-//                 .unary_operation_equals("exp", &std::exp)
-//                 .unary_operation_equals("fabs", &std::fabs)
-//                 .unary_operation_equals("floor", &std::floor)
-//                 .unary_operation_equals("log10", &std::log10)
-//                 .unary_operation_equals("log", &std::log)
-//                 .unary_operation_equals("round", &Op::round)
-//                 .unary_operation_equals("sin", &std::sin)
-//                 .unary_operation_equals("sinh", &std::sinh)
-//                 .unary_operation_equals("sqrt", &std::sqrt)
-//                 .unary_operation_equals("tan", &std::tan)
-//                 .unary_operation_equals("tanh", &std::tanh);
-//
-// #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
-//             FunctionFactoryAssert(new FunctionFactory)
-//                 .unary_operation_equals("log1p", &log1p)
-//                 .unary_operation_equals("acosh", &acosh)
-//                 .unary_operation_equals("asinh", &asinh)
-//                 .unary_operation_equals("atanh", &atanh);
-// #endif
-//         }
-//
-//         SECTION("Binary Functions") {
-//             FunctionFactoryAssert(new FunctionFactory)
-//                 .binary_operation_equals("atan2", &std::atan2)
-//                 .binary_operation_equals("eq", &Op::eq)
-//                 .binary_operation_equals("fmod", &std::fmod)
-//                 .binary_operation_equals("ge", &Op::ge)
-//                 .binary_operation_equals("gt", &Op::gt)
-//                 .binary_operation_equals("le", &Op::le)
-//                 .binary_operation_equals("lt", &Op::lt)
-//                 .binary_operation_equals("max", &Op::max)
-//                 .binary_operation_equals("min", &Op::min)
-//                 .binary_operation_equals("neq", &Op::neq)
-//                 .binary_operation_equals("pow", &std::pow);
-//         }
+        //
+        //         SECTION("Deregister all") {
+        //             FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        //         }
+        //
+        //         SECTION("Assign constructor") {
+        //             FunctionFactory only_operators;
+        //             for (auto function : only_operators.availableFunctions())
+        //                 only_operators.deregisterObject(function);
+        //             FunctionFactory ff;
+        //             ff = only_operators;
+        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //
+        //         SECTION("Copy constructor with operators") {
+        //             FunctionFactory only_operators;
+        //             for (auto function : only_operators.availableFunctions())
+        //                 only_operators.deregisterObject(function);
+        //             FunctionFactory ff(only_operators);
+        //             CHECK(ff.availableFunctions() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableOperators(), Catch::Matchers::UnorderedEquals(operators));
+        //         }
+        //         SECTION("Copy constructor with functions") {
+        //             FunctionFactory only_functions;
+        //             for (auto operator_ : only_functions.availableOperators())
+        //                 only_functions.deregisterObject(operator_);
+        //             FunctionFactory ff(only_functions);
+        //             CHECK(ff.availableOperators() == std::vector<std::string>{});
+        //             CHECK_THAT(ff.availableFunctions(), Catch::Matchers::UnorderedEquals(functions));
+        //         }
+        //
+        SECTION("Unary Operators") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("!", &Op::logicalNot)
+                .operation_is("!", 0, 1)
+                .operation_is("!", 1, 0)
+                .unary_operation_equals("~", &Op::negate)
+                .operation_is("~", 1, -1)
+                .operation_is("~", -2, 2)
+                .operation_is("~", 0, 0);
+        }
+        SECTION("Binary Operators") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .binary_operation_equals("^", &std::pow)
+                .operation_is("^", 3, 3, 27)
+                .operation_is("^", 9, 0.5, 3)
+                .binary_operation_equals("*", &Op::multiply)
+                .operation_is("*", -2, 3, -6)
+                .operation_is("*", 3, -2, -6)
+                .operation_is("*", 0, 0, 0)
+                .binary_operation_equals("/", &Op::divide)
+                .operation_is("/", 6, 3, 2)
+                .operation_is("/", 3, 6, 0.5)
+                .operation_is("/", 0, 0, fl::nan)
+                .operation_is("/", 1, 0, fl::inf)
+                .operation_is("/", -1, 0, -fl::inf)
+                .binary_operation_equals("%", &Op::modulo)
+                .operation_is("%", 6, 3, 0)
+                .operation_is("%", 3, 6, 3)
+                .operation_is("%", 3.5, 6, 3.5)
+                .operation_is("%", 6, 3.5, 2.5)
+                .binary_operation_equals("+", &Op::add)
+                .operation_is("+", 2, 3, 5)
+                .operation_is("+", 2, -3, -1)
+                .binary_operation_equals("-", &Op::subtract)
+                .operation_is("-", 2, 3, -1)
+                .operation_is("-", 2, -3, 5)
+                .binary_operation_equals("and", &Op::logicalAnd)
+                .operation_is("and", 1, 0, 0)
+                .operation_is("and", 1, 1, 1)
+                .binary_operation_equals("or", &Op::logicalOr)
+                .operation_is("or", 1, 0, 1)
+                .operation_is("or", 0, 0, 0);
+        }
+        //         SECTION("Unary functions") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .unary_operation_equals("abs", &std::abs)
+        //                 .unary_operation_equals("acos", &std::acos)
+        //                 .unary_operation_equals("asin", &std::asin)
+        //                 .unary_operation_equals("atan", &std::atan)
+        //                 .unary_operation_equals("ceil", &std::ceil)
+        //                 .unary_operation_equals("cos", &std::cos)
+        //                 .unary_operation_equals("cosh", &std::cosh)
+        //                 .unary_operation_equals("exp", &std::exp)
+        //                 .unary_operation_equals("fabs", &std::fabs)
+        //                 .unary_operation_equals("floor", &std::floor)
+        //                 .unary_operation_equals("log10", &std::log10)
+        //                 .unary_operation_equals("log", &std::log)
+        //                 .unary_operation_equals("round", &Op::round)
+        //                 .unary_operation_equals("sin", &std::sin)
+        //                 .unary_operation_equals("sinh", &std::sinh)
+        //                 .unary_operation_equals("sqrt", &std::sqrt)
+        //                 .unary_operation_equals("tan", &std::tan)
+        //                 .unary_operation_equals("tanh", &std::tanh);
+        //
+        // #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .unary_operation_equals("log1p", &log1p)
+        //                 .unary_operation_equals("acosh", &acosh)
+        //                 .unary_operation_equals("asinh", &asinh)
+        //                 .unary_operation_equals("atanh", &atanh);
+        // #endif
+        //         }
+        //
+        //         SECTION("Binary Functions") {
+        //             FunctionFactoryAssert(new FunctionFactory)
+        //                 .binary_operation_equals("atan2", &std::atan2)
+        //                 .binary_operation_equals("eq", &Op::eq)
+        //                 .binary_operation_equals("fmod", &std::fmod)
+        //                 .binary_operation_equals("ge", &Op::ge)
+        //                 .binary_operation_equals("gt", &Op::gt)
+        //                 .binary_operation_equals("le", &Op::le)
+        //                 .binary_operation_equals("lt", &Op::lt)
+        //                 .binary_operation_equals("max", &Op::max)
+        //                 .binary_operation_equals("min", &Op::min)
+        //                 .binary_operation_equals("neq", &Op::neq)
+        //                 .binary_operation_equals("pow", &std::pow);
+        //         }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -556,31 +556,31 @@ namespace fuzzylite {
         //     CHECK_THAT(FunctionFactory().available(), Catch::Matchers::UnorderedEquals(expected));
         // }
 
-        SECTION("Precedence is the same") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .precedence_is_the_same("!", "~")
-                .precedence_is_the_same("*", "/")
-                .precedence_is_the_same("/", "%")
-                .precedence_is_the_same("+", "-");
-        }
-        SECTION("Precedence is higher") {
-            FunctionFactoryAssert(new FunctionFactory)
-                .precedence_is_higher("!", "^")
-                .precedence_is_higher("^", "%")
-                .precedence_is_higher("*", "-")
-                .precedence_is_higher("+", "and")
-                .precedence_is_higher("and", "or");
-        }
-
-        SECTION("Precedence is correct") {
-            Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
-            f.load();
-            CHECK_THAT(f.evaluate(), Approximates(29.8125));
-        }
-
-        SECTION("Deregister all") {
-            FunctionFactoryAssert(new FunctionFactory).deregister_all();
-        }
+        // SECTION("Precedence is the same") {
+        //     FunctionFactoryAssert(new FunctionFactory)
+        //         .precedence_is_the_same("!", "~")
+        //         .precedence_is_the_same("*", "/")
+        //         .precedence_is_the_same("/", "%")
+        //         .precedence_is_the_same("+", "-");
+        // }
+        // SECTION("Precedence is higher") {
+        //     FunctionFactoryAssert(new FunctionFactory)
+        //         .precedence_is_higher("!", "^")
+        //         .precedence_is_higher("^", "%")
+        //         .precedence_is_higher("*", "-")
+        //         .precedence_is_higher("+", "and")
+        //         .precedence_is_higher("and", "or");
+        // }
+        //
+        // SECTION("Precedence is correct") {
+        //     Function f("f", "(10 + 5) * 2 - 3 / 4 ^ 2");
+        //     f.load();
+        //     CHECK_THAT(f.evaluate(), Approximates(29.8125));
+        // }
+        //
+        // SECTION("Deregister all") {
+        //     FunctionFactoryAssert(new FunctionFactory).deregister_all();
+        // }
 
         // SECTION("Assign constructor") {
         //     FunctionFactory only_operators;

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -652,50 +652,50 @@ namespace fuzzylite {
                 .operation_is("or", 1, 0, 1)
                 .operation_is("or", 0, 0, 0);
         }
-        //         SECTION("Unary functions") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .unary_operation_equals("abs", &std::abs)
-        //                 .unary_operation_equals("acos", &std::acos)
-        //                 .unary_operation_equals("asin", &std::asin)
-        //                 .unary_operation_equals("atan", &std::atan)
-        //                 .unary_operation_equals("ceil", &std::ceil)
-        //                 .unary_operation_equals("cos", &std::cos)
-        //                 .unary_operation_equals("cosh", &std::cosh)
-        //                 .unary_operation_equals("exp", &std::exp)
-        //                 .unary_operation_equals("fabs", &std::fabs)
-        //                 .unary_operation_equals("floor", &std::floor)
-        //                 .unary_operation_equals("log10", &std::log10)
-        //                 .unary_operation_equals("log", &std::log)
-        //                 .unary_operation_equals("round", &Op::round)
-        //                 .unary_operation_equals("sin", &std::sin)
-        //                 .unary_operation_equals("sinh", &std::sinh)
-        //                 .unary_operation_equals("sqrt", &std::sqrt)
-        //                 .unary_operation_equals("tan", &std::tan)
-        //                 .unary_operation_equals("tanh", &std::tanh);
-        //
-        // #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .unary_operation_equals("log1p", &log1p)
-        //                 .unary_operation_equals("acosh", &acosh)
-        //                 .unary_operation_equals("asinh", &asinh)
-        //                 .unary_operation_equals("atanh", &atanh);
-        // #endif
-        //         }
-        //
-        //         SECTION("Binary Functions") {
-        //             FunctionFactoryAssert(new FunctionFactory)
-        //                 .binary_operation_equals("atan2", &std::atan2)
-        //                 .binary_operation_equals("eq", &Op::eq)
-        //                 .binary_operation_equals("fmod", &std::fmod)
-        //                 .binary_operation_equals("ge", &Op::ge)
-        //                 .binary_operation_equals("gt", &Op::gt)
-        //                 .binary_operation_equals("le", &Op::le)
-        //                 .binary_operation_equals("lt", &Op::lt)
-        //                 .binary_operation_equals("max", &Op::max)
-        //                 .binary_operation_equals("min", &Op::min)
-        //                 .binary_operation_equals("neq", &Op::neq)
-        //                 .binary_operation_equals("pow", &std::pow);
-        //         }
+        SECTION("Unary functions") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("abs", &std::abs)
+                .unary_operation_equals("acos", &std::acos)
+                .unary_operation_equals("asin", &std::asin)
+                .unary_operation_equals("atan", &std::atan)
+                .unary_operation_equals("ceil", &std::ceil)
+                .unary_operation_equals("cos", &std::cos)
+                .unary_operation_equals("cosh", &std::cosh)
+                .unary_operation_equals("exp", &std::exp)
+                .unary_operation_equals("fabs", &std::fabs)
+                .unary_operation_equals("floor", &std::floor)
+                .unary_operation_equals("log10", &std::log10)
+                .unary_operation_equals("log", &std::log)
+                .unary_operation_equals("round", &Op::round)
+                .unary_operation_equals("sin", &std::sin)
+                .unary_operation_equals("sinh", &std::sinh)
+                .unary_operation_equals("sqrt", &std::sqrt)
+                .unary_operation_equals("tan", &std::tan)
+                .unary_operation_equals("tanh", &std::tanh);
+
+#if defined(FL_UNIX) && !defined(FL_USE_FLOAT)
+            FunctionFactoryAssert(new FunctionFactory)
+                .unary_operation_equals("log1p", &log1p)
+                .unary_operation_equals("acosh", &acosh)
+                .unary_operation_equals("asinh", &asinh)
+                .unary_operation_equals("atanh", &atanh);
+#endif
+        }
+
+        SECTION("Binary Functions") {
+            FunctionFactoryAssert(new FunctionFactory)
+                .binary_operation_equals("atan2", &std::atan2)
+                .binary_operation_equals("eq", &Op::eq)
+                .binary_operation_equals("fmod", &std::fmod)
+                .binary_operation_equals("ge", &Op::ge)
+                .binary_operation_equals("gt", &Op::gt)
+                .binary_operation_equals("le", &Op::le)
+                .binary_operation_equals("lt", &Op::lt)
+                .binary_operation_equals("max", &Op::max)
+                .binary_operation_equals("min", &Op::min)
+                .binary_operation_equals("neq", &Op::neq)
+                .binary_operation_equals("pow", &std::pow);
+        }
     }
 
     TEST_CASE("Factory Manager", "[factory]") {

--- a/test/TestFactory.cpp
+++ b/test/TestFactory.cpp
@@ -521,17 +521,16 @@ namespace fuzzylite {
         }
     };
 
-    TEST_CASE("FunctionFactory", "[factory][function]") {
-        const std::vector<std::string> operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
-        const std::vector<std::string> functions
-            = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
-               "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
-               "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
+    const std::vector<std::string> operators = {"!", "~", "%", "^", "*", "/", "+", "-", "and", "or"};
+    const std::vector<std::string> functions
+        = {"abs",   "acos",  "asin",  "atan",  "atan2", "ceil", "cos",  "cosh",  "eq",   "exp",
+           "fabs",  "floor", "fmod",  "ge",    "gt",    "le",   "log",  "log10", "lt",   "max",
+           "min",   "neq",   "pow",   "round", "sin",   "sinh", "sqrt", "tan",   "tanh",
 #if defined(FL_UNIX) && !defined(FL_USE_FLOAT)  // found in Unix when using double precision. not found in Windows.
-               "acosh", "asinh", "atanh", "log1p"
+           "acosh", "asinh", "atanh", "log1p"
 #endif
-            };
-
+    };
+    TEST_CASE("FunctionFactory", "[factory][function]") {
         SECTION("Cloning empty object returns null") {
             FunctionFactory ff;
             ff.registerObject("null", fl::null);

--- a/test/TestTerm.cpp
+++ b/test/TestTerm.cpp
@@ -27,10 +27,7 @@ namespace fuzzylite {
     struct TermAssert {
         FL_unique_ptr<Term> actual;
 
-        TermAssert(Term* actual) : actual(actual) {
-            // TODO: Remove once changed
-            fuzzylite::setMachEps(1e-3);
-        }
+        TermAssert(Term* actual) : actual(actual) {}
 
         TermAssert& exports_fll(const std::string& obtained, bool checkHeight = true) {
             CHECK(this->actual->toString() == obtained);


### PR DESCRIPTION
- Fix bug in `CloningFactory::available()` and descendants (eg, `FunctionFactory`): Not increasing iterator means it looped forever.
- Fix bug in `CloningFactory::deregisterObject` in Windows only, where the iterator became invalid after erasing it and then not finding the value pointer properly for deletion. After erasing the iterator, we deleted the object, leading to Catch2 to loop forever. The fix: we delete the object before erasing the iterator.
- Add clone methods to factories.
- Rename default name of Terms without name from `unnamed` to `_`
- New: `DefuzzifierFactory::[constructWeighted|constructIntegral]`